### PR TITLE
New Monitor plugin: Showing UV rate

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,9 @@ Otherwise, you'll need to install them yourself.
 :    Support for xpm image file format. This will allow loading .xpm files in `<icon>`.
      Requires the [libXpm] C library.
 
+`with_uvmeter`
+:    Enables UVMeter plugin. The plugin shows UV data for Australia.
+
 `all_extensions`
 :    Enables all the extensions above.
 
@@ -1242,6 +1245,19 @@ more than one battery.
 - Example:
 
     Run CatInt 0 "/sys/devices/platform/thinkpad_hwmon/fan1_input" [] 50
+
+### `UVMeter`
+
+- Aliases to `uvmeter`
+- Args: default monitor arguments.
+- Example:
+
+    Run UVMeter "brisbane" [] 900
+
+- *Reminder:* Keep the refresh rate high, to avoid making unnecessary
+  requests every time the plug-in is run.
+- Station IDs can be found here:
+  http://www.arpansa.gov.au/uvindex/realtime/xml/uvvalues.xml
 
 ## Executing External Commands
 

--- a/readme.md
+++ b/readme.md
@@ -1248,7 +1248,8 @@ more than one battery.
 
 ### `UVMeter`
 
-- Aliases to `uvmeter`
+- Aliases to "uv " + station id. For example: `%uv brisbane%` or `%uv
+  alice springs%`
 - Args: default monitor arguments.
 
 - *Reminder:* Keep the refresh rate high, to avoid making unnecessary

--- a/readme.md
+++ b/readme.md
@@ -1250,14 +1250,14 @@ more than one battery.
 
 - Aliases to `uvmeter`
 - Args: default monitor arguments.
-- Example:
-
-    Run UVMeter "brisbane" [] 900
 
 - *Reminder:* Keep the refresh rate high, to avoid making unnecessary
   requests every time the plug-in is run.
 - Station IDs can be found here:
   http://www.arpansa.gov.au/uvindex/realtime/xml/uvvalues.xml
+- Example:
+
+        Run UVMeter "brisbane" ["-H", "3", "-L", "3", "--low", "green", "--high", "red"] 900
 
 ## Executing External Commands
 

--- a/src/Plugins/Monitors.hs
+++ b/src/Plugins/Monitors.hs
@@ -21,7 +21,6 @@ import Plugins
 
 import Plugins.Monitors.Common (runM, runMD)
 import Plugins.Monitors.Weather
-import Plugins.Monitors.UVMeter
 import Plugins.Monitors.Net
 import Plugins.Monitors.Mem
 import Plugins.Monitors.Swap
@@ -37,6 +36,9 @@ import Plugins.Monitors.Disk
 import Plugins.Monitors.Top
 import Plugins.Monitors.Uptime
 import Plugins.Monitors.CatInt
+#ifdef UVMETER
+import Plugins.Monitors.UVMeter
+#endif
 #ifdef IWLIB
 import Plugins.Monitors.Wireless
 #endif
@@ -52,7 +54,6 @@ import Plugins.Monitors.Mpris
 #endif
 
 data Monitors = Weather      Station     Args Rate
-              | UVMeter      Station     Args Rate
               | Network      Interface   Args Rate
               | DynNetwork               Args Rate
               | BatteryP     Args        Args Rate
@@ -73,6 +74,9 @@ data Monitors = Weather      Station     Args Rate
               | TopMem       Args        Rate
               | Uptime       Args        Rate
               | CatInt       Int FilePath Args Rate
+#ifdef UVMETER
+              | UVMeter      Station     Args Rate
+#endif
 #ifdef IWLIB
               | Wireless Interface  Args Rate
 #endif
@@ -101,7 +105,6 @@ type DiskSpec  = [(String, String)]
 
 instance Exec Monitors where
     alias (Weather s _ _) = s
-    alias (UVMeter s _ _) = s
     alias (Network i _ _) = i
     alias (DynNetwork _ _) = "dynnetwork"
     alias (Thermal z _ _) = z
@@ -122,6 +125,9 @@ instance Exec Monitors where
     alias (DiskIO {}) = "diskio"
     alias (Uptime _ _) = "uptime"
     alias (CatInt n _ _ _) = "cat" ++ show n
+#ifdef UVMETER
+    alias (UVMeter s _ _) = "uvmeter"
+#endif
 #ifdef IWLIB
     alias (Wireless i _ _) = i ++ "wi"
 #endif
@@ -143,7 +149,6 @@ instance Exec Monitors where
     start (TopProc a r) = startTop a r
     start (TopMem a r) = runM a topMemConfig runTopMem r
     start (Weather s a r) = runMD (a ++ [s]) weatherConfig runWeather r weatherReady
-    start (UVMeter s a r) = runM (a ++ [s]) uvConfig runUVMeter r
     start (Thermal z a r) = runM (a ++ [z]) thermalConfig runThermal r
     start (ThermalZone z a r) =
       runM (a ++ [show z]) thermalZoneConfig runThermalZone r
@@ -159,6 +164,9 @@ instance Exec Monitors where
     start (DiskIO s a r) = startDiskIO s a r
     start (Uptime a r) = runM a uptimeConfig runUptime r
     start (CatInt _ s a r) = runM a catIntConfig (runCatInt s) r
+#ifdef UVMETER
+    start (UVMeter s a r) = runM (a ++ [s]) uvConfig runUVMeter r
+#endif
 #ifdef IWLIB
     start (Wireless i a r) = runM a wirelessConfig (runWireless i) r
 #endif

--- a/src/Plugins/Monitors.hs
+++ b/src/Plugins/Monitors.hs
@@ -126,7 +126,7 @@ instance Exec Monitors where
     alias (Uptime _ _) = "uptime"
     alias (CatInt n _ _ _) = "cat" ++ show n
 #ifdef UVMETER
-    alias (UVMeter s _ _) = "uvmeter"
+    alias (UVMeter s _ _) = "uv " ++ s
 #endif
 #ifdef IWLIB
     alias (Wireless i _ _) = i ++ "wi"

--- a/src/Plugins/Monitors.hs
+++ b/src/Plugins/Monitors.hs
@@ -21,6 +21,7 @@ import Plugins
 
 import Plugins.Monitors.Common (runM, runMD)
 import Plugins.Monitors.Weather
+import Plugins.Monitors.UVMeter
 import Plugins.Monitors.Net
 import Plugins.Monitors.Mem
 import Plugins.Monitors.Swap
@@ -51,6 +52,7 @@ import Plugins.Monitors.Mpris
 #endif
 
 data Monitors = Weather      Station     Args Rate
+              | UVMeter      Station     Args Rate
               | Network      Interface   Args Rate
               | DynNetwork               Args Rate
               | BatteryP     Args        Args Rate
@@ -99,6 +101,7 @@ type DiskSpec  = [(String, String)]
 
 instance Exec Monitors where
     alias (Weather s _ _) = s
+    alias (UVMeter s _ _) = s
     alias (Network i _ _) = i
     alias (DynNetwork _ _) = "dynnetwork"
     alias (Thermal z _ _) = z
@@ -140,6 +143,7 @@ instance Exec Monitors where
     start (TopProc a r) = startTop a r
     start (TopMem a r) = runM a topMemConfig runTopMem r
     start (Weather s a r) = runMD (a ++ [s]) weatherConfig runWeather r weatherReady
+    start (UVMeter s a r) = runM (a ++ [s]) uvConfig runUVMeter r
     start (Thermal z a r) = runM (a ++ [z]) thermalConfig runThermal r
     start (ThermalZone z a r) =
       runM (a ++ [show z]) thermalZoneConfig runThermalZone r

--- a/src/Plugins/Monitors/UVMeter.hs
+++ b/src/Plugins/Monitors/UVMeter.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Plugins.Monitors.UVMeter
+-- Copyright   :  (c) Róman Joost
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  Róman Joost
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- An australian uv monitor for Xmobar
+--
+-----------------------------------------------------------------------------
+
+module Plugins.Monitors.UVMeter where
+
+import Plugins.Monitors.Common
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+import Network.HTTP
+import Text.Read (readMaybe)
+import Text.XML
+import Text.XML.Cursor
+
+
+uvConfig :: IO MConfig
+uvConfig = mkMConfig
+       "<station>" -- template
+       ["station"                               -- available replacements
+       ]
+
+data UvInfo = UV { index :: String }
+    deriving (Show)
+
+uvURL :: String
+uvURL = "http://www.arpansa.gov.au/uvindex/realtime/xml/uvvalues.xml"
+
+getData :: IO LT.Text
+getData = do
+    let request = getRequest uvURL
+    body <- simpleHTTP request >>= getResponseBody
+    return (LT.pack body)
+
+textToXMLDocument :: LT.Text -> Cursor
+textToXMLDocument txt = fromDocument doc
+    where Right doc = parseText def txt
+
+formatUVRating :: Maybe Float -> Monitor String
+formatUVRating Nothing = getConfigValue naString
+formatUVRating (Just x) = do
+    uv <- showWithColors show x
+    parseTemplate [uv]
+
+getUVRating :: String -> Cursor -> Maybe Float
+getUVRating stid cursor = readMaybe raw
+    where raw = T.unpack $ T.concat $
+                cursor $// element "location"
+                    >=> attributeIs "id" (T.pack stid)
+                    >=> child
+                    >=> element "index"
+                    &// content
+
+runUVMeter :: [String] -> Monitor String
+runUVMeter [] = return "N.A."
+runUVMeter (s:_) = do
+    resp <- io getData
+    let doc = textToXMLDocument resp
+    let uv = getUVRating s doc
+    formatUVRating uv

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -74,6 +74,10 @@ flag with_threaded
   description: Use threaded runtime.
   default: False
 
+flag with_uvmeter
+  description: UVMeter only useful to australians.
+  default: False
+
 executable xmobar
     hs-source-dirs:     src
     main-is:            Main.hs
@@ -112,8 +116,6 @@ executable xmobar
       time,
       filepath,
       transformers,
-      text >= 0.11.0.8,
-      xml-conduit,
       X11 >= 1.6.1,
       mtl >= 2.1 && < 2.3,
       parsec == 3.1.*,
@@ -179,3 +181,7 @@ executable xmobar
        extra-libraries: Xpm
        other-modules: XPMFile
        cpp-options: -DXPM
+
+    if flag(with_uvmeter)
+       build-depends: text >= 0.11.0.8, xml-conduit
+       cpp-options: -DUVMETER

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -93,7 +93,8 @@ executable xmobar
       Plugins.Monitors.Swap, Plugins.Monitors.Thermal,
       Plugins.Monitors.ThermalZone, Plugins.Monitors.Top,
       Plugins.Monitors.Uptime, Plugins.Monitors.Weather,
-      Plugins.Monitors.Bright, Plugins.Monitors.CatInt
+      Plugins.Monitors.Bright, Plugins.Monitors.CatInt,
+      Plugins.Monitors.UVMeter
 
     ghc-prof-options:   -prof -auto-all
     ghc-options: -funbox-strict-fields -Wall -fno-warn-unused-do-bind
@@ -111,6 +112,8 @@ executable xmobar
       time,
       filepath,
       transformers,
+      text >= 0.11.0.8,
+      xml-conduit,
       X11 >= 1.6.1,
       mtl >= 2.1 && < 2.3,
       parsec == 3.1.*,

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -183,5 +183,5 @@ executable xmobar
        cpp-options: -DXPM
 
     if flag(with_uvmeter)
-       build-depends: text >= 0.11.0.8, xml-conduit
+       build-depends: text >= 0.11, xml-conduit
        cpp-options: -DUVMETER


### PR DESCRIPTION
Hi,

I live in Australia. One thing we're wary off is the sun and the bodies exposure to it. That's why I wrote this plugin to show the UV data from the Australian Radiation Protection agency. The plugin grabs the exported XML from the agency and updates it's value in an interval.

I'm not sure about any coding conventions and mind you, I've a beginner to Haskell. Please feel free to let me know if this Plugin makes sense to be included or not.
Due to the limited audience this plugin might serve, I've made it optional. I've also updated the readme in order to run this plugin.

If there are any code changes violating current style or more changes need to be made to include this, let me please know.

Thanks for the great software! Kind Regards.