### PR TITLE
De-ambiguify TimeLocale when DateZone is enabled

### DIFF
--- a/src/Localize.hsc
+++ b/src/Localize.hsc
@@ -19,7 +19,11 @@ module Localize
     ) where
 
 import Foreign.C
+#if ! MIN_VERSION_time(1,5,0)
 import qualified System.Locale as L
+#else
+import qualified Data.Time.Format as L
+#endif
 
 #ifdef UTF8
 import Codec.Binary.UTF8.String

--- a/src/Plugins/DateZone.hs
+++ b/src/Plugins/DateZone.hs
@@ -36,7 +36,9 @@ import Data.Time.Format
 import Data.Time.LocalTime.TimeZone.Olson
 import Data.Time.LocalTime.TimeZone.Series
 
+#if ! MIN_VERSION_time(1,5,0)
 import System.Locale (TimeLocale)
+#endif
 #else
 import System.IO
 import Plugins.Date


### PR DESCRIPTION
Fixes #225 

It seems I forgot to compile xmobar with all plugins, of course DateZone was disabled.