### PR TITLE
Added "-p" launch option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -394,6 +394,7 @@ xmobar --help):
       -A alpha      --alpha=alpha          The transparency: 0 is transparent, 255 (the default) is opaque
       -o            --top                  Place xmobar at the top of the screen
       -b            --bottom               Place xmobar at the bottom of the screen
+      -p            --position=position    Specificty position, same as in config file
       -d            --dock                 Try to start xmobar as a dock
       -a alignsep   --alignsep=alignsep    Separators for left, center and right text
                                            alignment. Default: '}{'

--- a/readme.md
+++ b/readme.md
@@ -394,7 +394,7 @@ xmobar --help):
       -A alpha      --alpha=alpha          The transparency: 0 is transparent, 255 (the default) is opaque
       -o            --top                  Place xmobar at the top of the screen
       -b            --bottom               Place xmobar at the bottom of the screen
-      -p            --position=position    Specificty position, same as in config file
+      -p            --position=position    Specify position, same as in config file
       -d            --dock                 Try to start xmobar as a dock
       -a alignsep   --alignsep=alignsep    Separators for left, center and right text
                                            alignment. Default: '}{'

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -170,7 +170,7 @@ options =
     , Option "x" ["screen"] (ReqArg OnScr "screen")
       "On which X screen number to start"
     , Option "p" ["position"] (ReqArg Position "position")
-      "Specify position of xmobar. This will override -o or -b"
+      "Specify position of xmobar. Same syntax as in config file"
     ]
 
 getOpts :: [String] -> IO ([Opts], [String])

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -39,7 +39,6 @@ import System.FilePath ((</>))
 import System.Posix.Files
 import Control.Monad (unless, liftM)
 import Text.Read (readMaybe)
-import Data.Maybe (fromMaybe)
 
 import Signal (setupSignalHandler)
 


### PR DESCRIPTION
`-p "string"` will override position settings set in configuration file.
Useful for launching multiple xmobars from single configuration file,
which is almost necessary when using non-monospace fonts.