### PR TITLE
feat(MPD): add <date> support in template

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1097,7 +1097,7 @@ more than one battery.
              `plength` (playlist length), `ppos` (playlist position),
              `flags` (ncmpcpp-style playback mode),
              `name`, `artist`, `composer`, `performer`,
-             `album`, `title`, `track`, `file`, `genre`
+             `album`, `title`, `track`, `file`, `genre`, `date`
 - Default template: `MPD: <state>`
 - Example (note that you need "--" to separate regular monitor options from
   MPD's specific ones):

--- a/src/Plugins/Monitors/MPD.hs
+++ b/src/Plugins/Monitors/MPD.hs
@@ -26,7 +26,7 @@ mpdConfig = mkMConfig "MPD: <state>"
               [ "bar", "vbar", "ipat", "state", "statei", "volume", "length"
               , "lapsed", "remaining", "plength", "ppos", "flags", "file"
               , "name", "artist", "composer", "performer"
-              , "album", "title", "track", "genre"
+              , "album", "title", "track", "genre", "date"
               ]
 
 data MOpts = MOpts
@@ -126,7 +126,7 @@ parseSong (Right Nothing) = return $ repeat ""
 parseSong (Right (Just s)) =
   let str sel = maybe "" (intercalate ", " . map M.toString) (M.sgGetTag sel s)
       sels = [ M.Name, M.Artist, M.Composer, M.Performer
-             , M.Album, M.Title, M.Track, M.Genre ]
+             , M.Album, M.Title, M.Track, M.Genre, M.Date ]
       fields = M.toString (M.sgFilePath s) : map str sels
   in mapM showWithPadding fields
 


### PR DESCRIPTION
Hi.

With this patch, users can now display the release date of their favorite songs playing on MPD.