### PR TITLE
Add expandEnv function and use it in PipeReader

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1344,6 +1344,7 @@ can be used in the output template as `%mydate%`
 
 - Reads its displayed output from the given pipe.
 - Prefix an optional default text separated by a colon
+- Expands environment variables in the first argument of syntax '${VAR}' or '$VAR'
 
 <font size="+1">**`MarqueePipeReader "default text:/path/to/pipe" (length, rate, sep) Alias`**</font>
 
@@ -1352,6 +1353,8 @@ can be used in the output template as `%mydate%`
   seconds and separator when it wraps around
 
         Run MarqueePipeReader "/tmp/testpipe" (10, 7, "+") "mpipe"
+
+- Expands environment variables in the first argument
 
 <font size="+1">
 **`BufferedPipeReader Alias [(Timeout, Bool, "/path/to/pipe1"), ..]`**
@@ -1382,6 +1385,7 @@ can be used in the output template as `%mydate%`
   `"/tmp/xmobar_status"` will reveal xmonad for 1.5 seconds and
   temporarily overwrite the window titles.
 - Take a look at [samples/status.sh]
+- Expands environment variables for the pipe path
 
 [samples/status.sh]: http://github.com/jaor/xmobar/raw/master/samples/status.sh
 

--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -1,0 +1,48 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMobar.Environment
+-- Copyright   :  (c) William Song
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  Will Song <incertia@incertia.net>
+-- Stability   :  stable
+-- Portability :  portable
+--
+-- A function to expand environment variables in strings
+--
+-----------------------------------------------------------------------------
+module Environment where
+
+import Data.Maybe           (fromMaybe)
+import System.Environment   (lookupEnv)
+
+expandEnv :: String -> IO String
+expandEnv "" = return ""
+expandEnv (c:s) = case c of
+  '$'       -> do
+    envVar <- fromMaybe "" <$> lookupEnv e
+    remainder <- expandEnv s'
+    return $ envVar ++ remainder
+    where (e, s') = getVar s
+          getVar "" = ("", "")
+          getVar ('{':s) = (takeUntil "}" s, drop 1 . dropUntil "}" $ s)
+          getVar s = (takeUntil filterstr s, dropUntil filterstr s)
+          filterstr = ",./? \t;:\"'~`!@#$%^&*()<>-+=\\|"
+          takeUntil f = takeWhile (not . flip elem f)
+          dropUntil f = dropWhile (not . flip elem f)
+
+  '\\' -> case s == "" of
+    True  -> return "\\"
+    False -> do
+      remainder <- expandEnv $ drop 1 s
+      return $ escString s ++ remainder
+      where escString s = let (cc:ss) = s in
+              case cc of
+                't' -> "\t"
+                'n' -> "\n"
+                '$' -> "$"
+                _   -> [cc]
+
+  _    -> do
+    remainder <- expandEnv s
+    return $ c : remainder

--- a/src/Plugins/BufferedPipeReader.hs
+++ b/src/Plugins/BufferedPipeReader.hs
@@ -20,6 +20,7 @@ import Control.Concurrent.STM
 import System.IO
 import System.IO.Unsafe(unsafePerformIO)
 
+import Environment
 import Plugins
 import Signal
 
@@ -51,7 +52,8 @@ instance Exec BufferedPipeReader where
 
         reader :: (Int, Bool, FilePath) -> TChan (Int, Bool, String) -> IO ()
         reader p@(to, tg, fp) tc = do
-            openFile fp ReadWriteMode >>= hGetLineSafe >>= \dt ->
+            fp' <- expandEnv fp
+            openFile fp' ReadWriteMode >>= hGetLineSafe >>= \dt ->
                 atomically $ writeTChan tc (to, tg, dt)
             reader p tc
 

--- a/src/Plugins/MarqueePipeReader.hs
+++ b/src/Plugins/MarqueePipeReader.hs
@@ -15,6 +15,7 @@
 module Plugins.MarqueePipeReader where
 
 import System.IO (openFile, IOMode(ReadWriteMode), Handle)
+import Environment
 import Plugins (tenthSeconds, Exec(alias, start), hGetLineSafe)
 import System.Posix.Files (getFileStatus, isNamedPipe)
 import Control.Concurrent(forkIO, threadDelay)
@@ -32,7 +33,7 @@ data MarqueePipeReader = MarqueePipeReader String (Length, Rate, Separator) Stri
 instance Exec MarqueePipeReader where
     alias (MarqueePipeReader _ _ a)    = a
     start (MarqueePipeReader p (len, rate, sep) _) cb = do
-        let (def, pipe) = split ':' p
+        (def, pipe) <- split ':' <$> expandEnv p
         unless (null def) (cb def)
         checkPipe pipe
         h <- openFile pipe ReadWriteMode

--- a/src/Plugins/PipeReader.hs
+++ b/src/Plugins/PipeReader.hs
@@ -16,6 +16,7 @@ module Plugins.PipeReader where
 
 import System.IO
 import Plugins
+import Environment
 import System.Posix.Files
 import Control.Concurrent(threadDelay)
 import Control.Exception
@@ -27,7 +28,7 @@ data PipeReader = PipeReader String String
 instance Exec PipeReader where
     alias (PipeReader _ a)    = a
     start (PipeReader p _) cb = do
-        let (def, pipe) = split ':' p
+        (def, pipe) <- split ':' <$> expandEnv p
         unless (null def) (cb def)
         checkPipe pipe
         h <- openFile pipe ReadWriteMode

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -88,6 +88,7 @@ executable xmobar
     other-modules:
       Xmobar, Actions, Bitmap, Config, Parsers, Commands, Localize,
       XUtil, XPMFile, StatFS, Runnable, ColorCache, Window, Signal,
+      Environment,
       Plugins, Plugins.BufferedPipeReader,
       Plugins.CommandReader, Plugins.Date, Plugins.EWMH,
       Plugins.PipeReader, Plugins.MarqueePipeReader,


### PR DESCRIPTION
expandEnv takes a string and expands the environment variables it can
find. variable substringing (e.g. ${VAR:1} to lop off the first
character) is not supported, but $VAR and ${VAR} formats are, with the
former being delimited by punctuation, but not underscores.

ideally, we should be able to do a one time expansion in all strings, but I do not know where to stick the function call.

this is useful, especially for pipereader, if you want to have a similar xmobar configuration across multiple x displays (say you are running a vnc server), and want to avoid race conditions by specifying a different pipe (say xmobar.pipe.${DISPLAY:1}) for each display.