### PR TITLE
tell the user what went wrong in the event of a failure

### DIFF
--- a/src/Xmobar.hs
+++ b/src/Xmobar.hs
@@ -106,8 +106,8 @@ startLoop xcfg@(XConf _ _ w _ _ _) sig vs = do
 #endif
     eventLoop tv xcfg [] sig
   where
-    handler thing (SomeException _) =
-      void $ putStrLn ("Thread " ++ thing ++ " failed")
+    handler thing (SomeException e) =
+      void $ putStrLn ("Thread " ++ thing ++ " failed: " ++ (show e))
     -- Reacts on events from X
     eventer signal =
       allocaXEvent $ \e -> do


### PR DESCRIPTION
with this patch, it will now give more info on what is failing when things go wrong, for example:

``Thread checker failed: thread blocked indefinitely in an STM transaction``
