### PR TITLE
When xpm flag is disabled don't use XPMFile in preprocessor

### DIFF
--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -87,7 +87,7 @@ executable xmobar
     main-is:            Main.hs
     other-modules:
       Xmobar, Actions, Bitmap, Config, Parsers, Commands, Localize,
-      XUtil, XPMFile, StatFS, Runnable, ColorCache, Window, Signal,
+      XUtil, StatFS, Runnable, ColorCache, Window, Signal,
       Environment,
       Plugins, Plugins.BufferedPipeReader,
       Plugins.CommandReader, Plugins.Date, Plugins.EWMH,


### PR DESCRIPTION
Otherwise build fails on preprocessor stage as:
  Building xmobar-0.24.3...
  Preprocessing executable 'xmobar' for xmobar-0.24.3...
  XPMFile.hsc:29:21: fatal error: X11/xpm.h: No such file or directory
  compilation terminated.

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/601262
Signed-off-by: Sergei Trofimovich <siarheit@google.com>