### PR TITLE
readme: specify package name for iwlib on Arch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ Otherwise, you'll need to install them yourself.
 :    Support for wireless cards. Enables the Wireless plugin. No Haskell
      library is required, but you will need the [iwlib] C library and
      headers in your system (e.g., install `libiw-dev` in Debian-based
-     systems).
+     systems or `wireless_tools` on Arch Linux).
 
 `with_alsa`
 :    Support for ALSA sound cards. Enables the Volume plugin. Requires the


### PR DESCRIPTION
On Arch Linux, the package providing `iwlib` is a bit hard to find - it
should come from the official `wireless_tools` package [1]. I've updated
the readme to make this more clear.

[1] https://www.archlinux.org/packages/?q=wireless_tools