### PR TITLE
Remove UVMeter from global 'other-modules' list

### DIFF
--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -106,8 +106,7 @@ executable xmobar
       Plugins.Monitors.Swap, Plugins.Monitors.Thermal,
       Plugins.Monitors.ThermalZone, Plugins.Monitors.Top,
       Plugins.Monitors.Uptime, Plugins.Monitors.Weather,
-      Plugins.Monitors.Bright, Plugins.Monitors.CatInt,
-      Plugins.Monitors.UVMeter
+      Plugins.Monitors.Bright, Plugins.Monitors.CatInt
 
     ghc-options: -funbox-strict-fields -Wall -fno-warn-unused-do-bind
     extra-libraries: Xrandr Xrender
@@ -196,4 +195,5 @@ executable xmobar
        cpp-options: -DXPM
 
     if flag(with_uvmeter)
+       other-modules: Plugins.Monitors.UVMeter
        cpp-options: -DUVMETER


### PR DESCRIPTION
List the module UVMeter within the conditional branch of the flag 'with_uvmeter' instead of the global 'other-modules'.