### PR TITLE
Fix UVMeter due to changed URL and BOM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,7 +158,8 @@ Otherwise, you'll need to install them yourself.
      Requires the [libXpm] C library.
 
 `with_uvmeter`
-:    Enables UVMeter plugin. The plugin shows UV data for Australia.
+:    Enables UVMeter plugin. The plugin shows UV data for Australia. Requires
+     `with_conduit` to connect to HTTPS URLs.
 
 `with_weather`
 :    Support to display weather information. Enables Weather plugin.

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -201,6 +201,7 @@ executable xmobar
           build-depends: http-conduit, http-types
           cpp-options: -DHTTP_CONDUIT
 
-    if flag(with_uvmeter)
+    if flag(with_uvmeter) && flag(with_conduit)
        other-modules: Plugins.Monitors.UVMeter
+       build-depends: http-conduit, http-types
        cpp-options: -DUVMETER


### PR DESCRIPTION
The URL which exports the real time UV data has changed to an HTTPS
address. Since the HTTP package does not support HTTPS URLs, use
http-conduit to retrieve the XML document.

Unfortunately, the XML documents XML declaration precedes a byte order
mark which the previous XML parser was unable to handle. We're simply
ignoring the BOM in order to get to the UV values.