### PR TITLE
Fixing a dependency error with dbus

### DIFF
--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -178,12 +178,12 @@ executable xmobar
        cpp-options: -DDATEZONE
 
     if flag(with_mpris) || flag(all_extensions)
-       build-depends: dbus >= 0.10
+       build-depends: dbus >= 0.10 && <= 0.10.12
        other-modules: Plugins.Monitors.Mpris
        cpp-options: -DMPRIS
 
     if flag(with_dbus) || flag(all_extensions)
-       build-depends: dbus >= 0.10
+       build-depends: dbus >= 0.10 && <= 0.10.12
        other-modules: IPC.DBus
        cpp-options: -DDBUS
 


### PR DESCRIPTION
Versions of dbus > 0.13 are problematic when using cabal to build the project.