### PR TITLE
Fix travis/CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,4 @@ install:
   - wget https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh
 
 script:
-  - sh ./travis.sh src
   - cabal configure --enable-tests -fall_extensions && cabal build && cabal test


### PR DESCRIPTION
The Travis CI fails due to the command sh ./travis.sh src returns an
error due to the fact that travis.sh does not exist.

The fix is removing the command from travis.yml.