### PR TITLE
Change behaviour of CpuFreq plugin

### DIFF
--- a/src/Plugins/Monitors/CpuFreq.hs
+++ b/src/Plugins/Monitors/CpuFreq.hs
@@ -35,8 +35,9 @@ runCpuFreq _ = do
   ddigits <- getConfigValue decDigits
   let path = ["/sys/devices/system/cpu/cpu", "/cpufreq/scaling_cur_freq"]
       divisor = 1e6 :: Double
-      fmt x | x < 1 = show (round (x * 1000) :: Integer) ++
+      fmt x | x < 1 = mhzFmt x ++
                       if suffix then "MHz" else ""
-            | otherwise = showDigits ddigits x ++ if suffix then "GHz" else ""
+            | otherwise = if suffix then showDigits ddigits x ++ "GHz" else mhzFmt x
+      mhzFmt x = show (round (x * 1000) :: Integer)
   failureMessage <- getConfigValue naString
   checkedDataRetrieval failureMessage [path] Nothing (/divisor) fmt

--- a/src/Plugins/Monitors/CpuFreq.hs
+++ b/src/Plugins/Monitors/CpuFreq.hs
@@ -39,6 +39,6 @@ runCpuFreq _ = do
                                 else ghzFmt x
             | otherwise = ghzFmt x ++ if suffix then "GHz" else ""
       mhzFmt x = show (round (x * 1000) :: Integer)
-      ghzFmt x = showDigits ddigits x
+      ghzFmt = showDigits ddigits
   failureMessage <- getConfigValue naString
   checkedDataRetrieval failureMessage [path] Nothing (/divisor) fmt

--- a/src/Plugins/Monitors/CpuFreq.hs
+++ b/src/Plugins/Monitors/CpuFreq.hs
@@ -32,10 +32,11 @@ cpuFreqConfig =
 runCpuFreq :: [String] -> Monitor String
 runCpuFreq _ = do
   suffix <- getConfigValue useSuffix
+  ddigits <- getConfigValue decDigits
   let path = ["/sys/devices/system/cpu/cpu", "/cpufreq/scaling_cur_freq"]
       divisor = 1e6 :: Double
       fmt x | x < 1 = show (round (x * 1000) :: Integer) ++
                       if suffix then "MHz" else ""
-            | otherwise = show x ++ if suffix then "GHz" else ""
+            | otherwise = showDigits ddigits x ++ if suffix then "GHz" else ""
   failureMessage <- getConfigValue naString
   checkedDataRetrieval failureMessage [path] Nothing (/divisor) fmt

--- a/src/Plugins/Monitors/CpuFreq.hs
+++ b/src/Plugins/Monitors/CpuFreq.hs
@@ -35,9 +35,10 @@ runCpuFreq _ = do
   ddigits <- getConfigValue decDigits
   let path = ["/sys/devices/system/cpu/cpu", "/cpufreq/scaling_cur_freq"]
       divisor = 1e6 :: Double
-      fmt x | x < 1 = mhzFmt x ++
-                      if suffix then "MHz" else ""
-            | otherwise = if suffix then showDigits ddigits x ++ "GHz" else mhzFmt x
+      fmt x | x < 1 = if suffix then mhzFmt x ++ "MHz"
+                                else ghzFmt x
+            | otherwise = ghzFmt x ++ if suffix then "GHz" else ""
       mhzFmt x = show (round (x * 1000) :: Integer)
+      ghzFmt x = showDigits ddigits x
   failureMessage <- getConfigValue naString
   checkedDataRetrieval failureMessage [path] Nothing (/divisor) fmt


### PR DESCRIPTION
1. Make GHz value honour -d (decimal digits) switch since it is a decimal point value.
2. If -S (suffix) if false, the number should be of the same unit, so I think it should display MHz value.