### PR TITLE
Add ellipsis option for Monitor's fields and total text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 cabal.sandbox.config
 .stack-work
 /web/readme.md
+/.idea/
+/xmobar.iml
+/out/
+/cabal.config

--- a/readme.md
+++ b/readme.md
@@ -642,6 +642,11 @@ These are the options available for all monitors below:
       than this value will be truncated.
     - Long option: `--maxwidth`
     - Default: 0 (no maximum width)
+- `-e` _string_ Maximum width ellipsis
+    - Ellipsis to be added to the field when it has reached its
+      max width.
+    - Long option: `--maxwidthellipsis`
+    - Default: "" (no ellipsis)
 - `-w` _number_ Fixed field width
     - All fields will be set to this width, padding or truncating as
       needed.
@@ -651,6 +656,11 @@ These are the options available for all monitors below:
     - Maximum total width of the text.
     - Long option: `--maxtwidth`
     - Default: 0 (no limit)
+- `-E` _string_ Maximum total width ellipsis
+    - Ellipsis to be added to the total text when it has reached
+      its max width.
+    - Long option: `--maxtwidthellipsis`
+    - Default: "" (no ellipsis)
 - `-c` _string_
     - Characters used for padding. The characters of _string_ are used
       cyclically. E.g., with `-P +- -w 6`, a field with value "foo"

--- a/src/Plugins/Monitors/Top.hs
+++ b/src/Plugins/Monitors/Top.hs
@@ -80,7 +80,7 @@ showInfo nm sms mms = do
   let lsms = length sms
       nmw = mnw - lsms - 1
       nmx = mxw - lsms - 1
-      rnm = if nmw > 0 then padString nmw nmx " " True nm else nm
+      rnm = if nmw > 0 then padString nmw nmx " " True "" nm else nm
   mstr <- showWithColors' sms mms
   both <- showWithColors' (rnm ++ " " ++ sms) mms
   return [nm, mstr, both]

--- a/test/Plugins/Monitors/CommonSpec.hs
+++ b/test/Plugins/Monitors/CommonSpec.hs
@@ -1,0 +1,29 @@
+module Plugins.Monitors.CommonSpec
+  ( main
+  , spec
+  ) where
+
+import Test.Hspec
+import Plugins.Monitors.Common
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec =
+  describe "Common.padString" $ do
+    it "returns given string when called with default values" $
+      do padString 0 0 "" False "" "test" `shouldBe` "test"
+
+    it "truncates to max width" $ do
+      let maxw = 3
+          givenStr = "mylongstr"
+          expectedStr = take maxw givenStr
+      padString 0 maxw "" False "" givenStr `shouldBe` expectedStr
+
+    it "truncates to max width and concatenate with ellipsis" $ do
+      let maxw = 3
+          givenStr = "mylongstr"
+          ellipsis = "..."
+          expectedStr = (++ ellipsis) . take 3 $ givenStr
+      padString 0 maxw "" False ellipsis givenStr `shouldBe` expectedStr

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -21,6 +21,48 @@ extra-source-files: readme.md, changelog.md,
                     samples/Plugins/helloworld.config,
                     samples/Plugins/HelloWorld.hs
 
+test-suite XmobarTest
+  type:           exitcode-stdio-1.0
+  hs-source-dirs:
+    src,
+    test
+  main-is:        Spec.hs
+  other-modules:
+        Xmobar, Actions, Bitmap, Config, Parsers, Commands, Localize,
+        XUtil, StatFS, Runnable, ColorCache, Window, Signal,
+        Environment,
+        Plugins, Plugins.BufferedPipeReader,
+        Plugins.CommandReader, Plugins.Date, Plugins.EWMH,
+        Plugins.PipeReader, Plugins.MarqueePipeReader,
+        Plugins.StdinReader, Plugins.XMonadLog,
+        Plugins.Utils, Plugins.Kbd, Plugins.Locks, Plugins.Monitors,
+        Plugins.Monitors.Batt, Plugins.Monitors.Common,
+        Plugins.Monitors.CoreCommon, Plugins.Monitors.CoreTemp,
+        Plugins.Monitors.CpuFreq, Plugins.Monitors.Cpu,
+        Plugins.Monitors.Disk, Plugins.Monitors.Mem,
+        Plugins.Monitors.MultiCpu, Plugins.Monitors.Net,
+        Plugins.Monitors.Swap, Plugins.Monitors.Thermal,
+        Plugins.Monitors.ThermalZone, Plugins.Monitors.Top,
+        Plugins.Monitors.Uptime,
+        Plugins.Monitors.Bright, Plugins.Monitors.CatInt
+  build-depends:
+    base == 4.*,
+    hspec == 2.*,
+    containers,
+    regex-compat,
+    process,
+    old-locale,
+    bytestring,
+    directory,
+    unix,
+    time,
+    filepath,
+    transformers,
+    X11 >= 1.6.1,
+    mtl >= 2.1 && < 2.3,
+    parsec == 3.1.*,
+    stm >= 2.3 && < 2.5
+
 source-repository head
   type:      git
   location:  git://github.com/jaor/xmobar.git


### PR DESCRIPTION
1. Add global ellipsis option for both Monitor's fields and total texts 
2. Add tests infrastructure based on hspec and tests on the new option
3. Add IntelliJ projects files to the gitignore