### PR TITLE
Add fallback icon support to MultiCpu

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -814,6 +814,8 @@ something like:
   - `--load-icon-patterns`: dynamic string for each cpu load in `autoipat`, `ipat{i}`.
                               This option can be specified several times. nth option
                               corresponds to nth cpu.
+  - `--fallback-icon-pattern`: dynamic string used by `autoipat` and `ipat{i}` when no
+                             `--load-icon-patterns` has been provided for `cpu{i}`
 - Thresholds refer to percentage of CPU load
 - Variables that can be used with the `-t`/`--template` argument:
 	    `autototal`, `autobar`, `autovbar`, `autoipat`, `autouser`, `autonice`,

--- a/src/Plugins/Monitors/MultiCpu.hs
+++ b/src/Plugins/Monitors/MultiCpu.hs
@@ -24,12 +24,14 @@ import System.Console.GetOpt
 data MultiCpuOpts = MultiCpuOpts
   { loadIconPatterns :: [IconPattern]
   , loadIconPattern :: Maybe IconPattern
+  , fallbackIconPattern :: Maybe IconPattern
   }
 
 defaultOpts :: MultiCpuOpts
 defaultOpts = MultiCpuOpts
   { loadIconPatterns = []
   , loadIconPattern = Nothing
+  , fallbackIconPattern = Nothing
   }
 
 options :: [OptDescr (MultiCpuOpts -> MultiCpuOpts)]
@@ -38,6 +40,8 @@ options =
      o { loadIconPattern = Just $ parseIconPattern x }) "") ""
   , Option "" ["load-icon-patterns"] (ReqArg (\x o ->
      o { loadIconPatterns = parseIconPattern x : loadIconPatterns o }) "") ""
+  , Option "" ["fallback-icon-pattern"] (ReqArg (\x o ->
+     o { fallbackIconPattern = Just $ parseIconPattern x }) "") ""
   ]
 
 parseOpts :: [String] -> IO MultiCpuOpts
@@ -97,7 +101,7 @@ formatCpu opts i xs
   where tryString
           | i == 0 = loadIconPattern opts
           | i <= length (loadIconPatterns opts) = Just $ loadIconPatterns opts !! (i - 1)
-          | otherwise = Nothing
+          | otherwise = fallbackIconPattern opts
 
 splitEvery :: Int -> [a] -> [[a]]
 splitEvery n = unfoldr (\x -> if null x then Nothing else Just $ splitAt n x)


### PR DESCRIPTION
To make the `<autoipat>` pattern truly automatic, there needs to be a fallback
icon set to use when the user hasn't specified enough `--load-icon-patterns`.
This adds the fallback under the name `--fallback-icon-pattern`