### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,8 @@ Xmobar is available from [Hackage], and you can install it using
 
         cabal install xmobar
 
+Xmobar versions >= 0.27 require GHC version >= 8.0.2.
+
 See below for a list of optional compilation flags that will enable
 some optional plugins. For instance, to install xmobar with all the
 bells and whistles, use:


### PR DESCRIPTION
This PR just adds a note about Xmobar versions 0.27 and up requiring GHC 8.0.2 or later.

Debian Stretch (stable) is pinned to GHC 8.0.1, so this will presumably be an issue for some Debian users for the next year or so until the next Debian release.

I'm not sure if this warrants adding a note about it to the docs, but it was something that tripped me up, so I thought I'd send a PR and let you decide if you think it belongs in the README. Don't feel bad if you decide to not merge this PR!

Thanks.