### PR TITLE
Add event-based refreshing for Volume plugin (--monitor option)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist/
+/dist-newstyle/
 /TAGS
 /IWlib.hs
 /StatFS.hs
@@ -17,3 +18,5 @@ cabal.sandbox.config
 /xmobar.iml
 /out/
 /cabal.config
+codex.tags
+cabal.project.local

--- a/readme.md
+++ b/readme.md
@@ -1063,6 +1063,14 @@ more than one battery.
     - `--highd` _number_ High threshold for dB. Defaults to -5.0.
     - `--lowd` _number_ Low threshold for dB. Defaults to -30.0.
     - `--volume-icon-pattern` _string_ dynamic string for current volume in `volumeipat`.
+    - `--monitor[=/path/to/alsactl]`
+        - Use event-based refreshing via `alsactl monitor` instead of polling
+          (`RefreshRate` will be ignored).
+        - If no `/path/to/alsactl` is given, `alsactl` will be sought in your `PATH`
+          first, and failing that, at `/usr/sbin/alsactl` (this is its location on
+          Debian systems. `alsactl monitor` works as a non-root user despite living
+          in `/usr/sbin`.).
+        - `stdbuf` (from coreutils) must be (and most probably already is) in your `PATH`.
 - Variables that can be used with the `-t`/`--template` argument:
             `volume`, `volumebar`, `volumevbar`, `volumeipat`, `dB`, `status`
 - Note that `dB` might only return 0 on your system. This is known

--- a/readme.md
+++ b/readme.md
@@ -1063,14 +1063,6 @@ more than one battery.
     - `--highd` _number_ High threshold for dB. Defaults to -5.0.
     - `--lowd` _number_ Low threshold for dB. Defaults to -30.0.
     - `--volume-icon-pattern` _string_ dynamic string for current volume in `volumeipat`.
-    - `--monitor[=/path/to/alsactl]`
-        - Use event-based refreshing via `alsactl monitor` instead of polling
-          (`RefreshRate` will be ignored).
-        - If no `/path/to/alsactl` is given, `alsactl` will be sought in your `PATH`
-          first, and failing that, at `/usr/sbin/alsactl` (this is its location on
-          Debian systems. `alsactl monitor` works as a non-root user despite living
-          in `/usr/sbin`.).
-        - `stdbuf` (from coreutils) must be (and most probably already is) in your `PATH`.
 - Variables that can be used with the `-t`/`--template` argument:
             `volume`, `volumebar`, `volumevbar`, `volumeipat`, `dB`, `status`
 - Note that `dB` might only return 0 on your system. This is known
@@ -1079,6 +1071,21 @@ more than one battery.
 - Requires the package [alsa-core] and [alsa-mixer] installed in your
   system. In addition, to activate this plugin you must pass
   `--flags="with_alsa"` during compilation.
+
+### `Alsa Mixer Element Args`
+
+Like [Volume](#volume-mixer-element-args-refreshrate), but with the following differences:
+- Uses event-based refreshing via `alsactl monitor` instead of polling, so it will refresh
+  instantly when there's a volume change, and won't use CPU until a change happens.
+- Aliases to `alsa:` followed by the mixer name and element name separated by a colon. Thus,
+  `Alsa "default" "Master" []` can be used as `%alsa:default:Master%`.
+- Additional options (after the `--`):
+    - `--alsactl=/path/to/alsactl`
+        - If this option is not specified, `alsactl` will be sought in your `PATH`
+          first, and failing that, at `/usr/sbin/alsactl` (this is its location on
+          Debian systems. `alsactl monitor` works as a non-root user despite living
+          in `/usr/sbin`.).
+- `stdbuf` (from coreutils) must be (and most probably already is) in your `PATH`.
 
 ### `MPD Args RefreshRate`
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -38,18 +38,18 @@ import System.Exit
 import System.Environment
 import System.FilePath ((</>))
 import System.Posix.Files
-import Control.Exception
 import Control.Concurrent.Async (Async, cancel)
+import Control.Exception (bracket)
 import Control.Monad (unless)
 import Text.Read (readMaybe)
 
-import Signal (setupSignalHandler)
+import Signal (setupSignalHandler, withDeferSignals)
 
 -- $main
 
 -- | The main entry point
 main :: IO ()
-main = do
+main = withDeferSignals $ do
   initThreads
   d <- openDisplay ""
   args <- getArgs
@@ -77,6 +77,7 @@ main = do
 
 cleanupThreads :: [[([Async ()], a)]] -> IO ()
 cleanupThreads vars =
+  -- putStrLn "In cleanupThreads"
   for_ (concat vars) $ \(asyncs, _) ->
     for_ asyncs cancel
 

--- a/src/Plugins/Monitors.hs
+++ b/src/Plugins/Monitors.hs
@@ -50,6 +50,7 @@ import Plugins.Monitors.Common (runMBD)
 #endif
 #ifdef ALSA
 import Plugins.Monitors.Volume
+import Plugins.Monitors.Alsa
 #endif
 #ifdef MPRIS
 import Plugins.Monitors.Mpris
@@ -90,6 +91,7 @@ data Monitors = Network      Interface   Args Rate
 #endif
 #ifdef ALSA
               | Volume   String     String Args Rate
+              | Alsa     String     String Args
 #endif
 #ifdef MPRIS
               | Mpris1   String     Args Rate
@@ -143,6 +145,7 @@ instance Exec Monitors where
 #endif
 #ifdef ALSA
     alias (Volume m c _ _) = m ++ ":" ++ c
+    alias (Alsa m c _) = "alsa:" ++ m ++ ":" ++ c
 #endif
 #ifdef MPRIS
     alias (Mpris1 _ _ _) = "mpris1"
@@ -183,7 +186,8 @@ instance Exec Monitors where
     start (AutoMPD a) = runMBD a mpdConfig runMPD mpdWait mpdReady
 #endif
 #ifdef ALSA
-    start (Volume m c a r) = startVolume m c a r
+    start (Volume m c a r) = runM a volumeConfig (runVolume m c) r
+    start (Alsa m c a) = startAlsaPlugin m c a
 #endif
 #ifdef MPRIS
     start (Mpris1 s a r) = runM a mprisConfig (runMPRIS1 s) r

--- a/src/Plugins/Monitors.hs
+++ b/src/Plugins/Monitors.hs
@@ -183,7 +183,7 @@ instance Exec Monitors where
     start (AutoMPD a) = runMBD a mpdConfig runMPD mpdWait mpdReady
 #endif
 #ifdef ALSA
-    start (Volume m c a r) = runM a volumeConfig (runVolume m c) r
+    start (Volume m c a r) = startVolume m c a r
 #endif
 #ifdef MPRIS
     start (Mpris1 s a r) = runM a mprisConfig (runMPRIS1 s) r

--- a/src/Plugins/Monitors/Alsa.hs
+++ b/src/Plugins/Monitors/Alsa.hs
@@ -1,0 +1,149 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Plugins.Monitors.Alsa
+-- Copyright   :  (c) 2018 Daniel Schüssler
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  Jose A. Ortega Ruiz <jao@gnu.org>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- Event-based variant of the Volume plugin.
+--
+-----------------------------------------------------------------------------
+
+module Plugins.Monitors.Alsa
+  ( startAlsaPlugin
+  , getMonitorWaiter
+  , parseOptsIncludingMonitorArgs
+  , AlsaOpts(aoAlsaCtlPath)
+  ) where
+
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Plugins.Monitors.Common
+import Plugins.Monitors.Volume(volumeConfig, VolumeOpts, runVolumeWith)
+import qualified Plugins.Monitors.Volume as Volume;
+import System.Console.GetOpt
+import System.Directory
+import System.Exit
+import System.IO
+import System.Process
+
+data AlsaOpts = AlsaOpts
+    { aoVolumeOpts :: VolumeOpts
+    , aoAlsaCtlPath :: Maybe FilePath
+    }
+
+defaultOpts :: AlsaOpts
+defaultOpts = AlsaOpts Volume.defaultOpts Nothing
+
+alsaCtlOptionName :: String
+alsaCtlOptionName = "alsactl"
+
+options :: [OptDescr (AlsaOpts -> AlsaOpts)]
+options =
+    Option "" [alsaCtlOptionName] (ReqArg (\x o ->
+       o { aoAlsaCtlPath = Just x }) "") ""
+    : fmap (fmap modifyVolumeOpts) Volume.options
+  where
+    modifyVolumeOpts f o = o { aoVolumeOpts = f (aoVolumeOpts o) }
+
+parseOpts :: [String] -> IO AlsaOpts
+parseOpts argv =
+    case getOpt Permute options argv of
+        (o, _, []) -> return $ foldr id defaultOpts o
+        (_, _, errs) -> ioError . userError $ concat errs
+
+parseOptsIncludingMonitorArgs :: [String] -> IO AlsaOpts
+parseOptsIncludingMonitorArgs args =
+    -- Drop generic Monitor args first
+    case getOpt Permute [] args of
+      (_, args', _) -> parseOpts args'
+
+startAlsaPlugin :: String -> String -> [String] -> (String -> IO ()) -> IO ()
+startAlsaPlugin mixerName controlName args cb = do
+  opts <- parseOptsIncludingMonitorArgs args
+
+  waitFunction <- getMonitorWaiter mixerName (aoAlsaCtlPath opts)
+
+  let run args2 = do
+        -- Replicating the reparsing logic used by other plugins for now,
+        -- but it seems the option parsing could be floated out (actually,
+        -- GHC could in principle do it already since getOpt is pure, but
+        -- it would have to inline 'runMBD', 'doArgs' and 'parseOpts' to see
+        -- it, which probably isn't going to happen with the default
+        -- optimization settings).
+        opts2 <- io $ parseOpts args2
+        runVolumeWith (aoVolumeOpts opts2) mixerName controlName
+
+  runMB args volumeConfig run waitFunction cb
+
+getMonitorWaiter :: String -> Maybe FilePath -> IO (IO ())
+getMonitorWaiter mixerName alsaCtlPath = do
+  mvar <- newMVar Nothing :: IO (MVar (Maybe SomeException))
+
+  forkFinally (readerThread mvar) (putMVar mvar . either Just (const Nothing))
+
+  pure $ do
+    ei <- takeMVar mvar
+    case ei of
+      -- Propagate exceptions from reader thread
+      Just (SomeException ex) -> throwIO ex
+      Nothing -> pure ()
+
+  where
+
+    readerThread mvar = do
+          path <- determineAlsaCtlPath
+          withCreateProcess
+            (proc "stdbuf" ["-oL", path, "monitor", mixerName]) {std_out = CreatePipe}
+            run
+
+      where
+
+        defaultPath = "/usr/sbin/alsactl"
+
+        determineAlsaCtlPath =
+          case alsaCtlPath of
+            Just path -> do
+              found <- doesFileExist path
+              if found
+                then pure path
+                else throwIO . ErrorCall $
+                     "Specified alsactl file " ++ path ++ " does not exist"
+
+            Nothing -> do
+              (ec, path, err) <- readProcessWithExitCode "which" ["alsactl"] ""
+              unless (null err) $ hPutStrLn stderr err
+              case ec of
+                ExitSuccess -> pure $ trimTrailingNewline path
+                ExitFailure _ -> do
+                  found <- doesFileExist defaultPath
+                  if found
+                    then pure defaultPath
+                    else throwIO . ErrorCall $
+                         "alsactl not found in PATH or at " ++
+                         show defaultPath ++
+                         "; please specify with --" ++
+                         alsaCtlOptionName ++ "=/path/to/alsactl"
+
+
+        run _ ~(Just out) _ _ = do
+          hSetBuffering out LineBuffering
+          forever $ do
+            c <- hGetChar out
+            when (c == '\n') $
+              -- This uses 'tryPutMVar' because 'putMVar' would make 'runVolume' run
+              -- once for each event. But we want it to run only once after a burst
+              -- of events.
+              void $ tryPutMVar mvar Nothing
+
+-- This is necessarily very inefficient on 'String's
+trimTrailingNewline :: String -> String
+trimTrailingNewline x =
+  case reverse x of
+    '\n' : '\r' : y -> reverse y
+    '\n' : y -> reverse y
+    _ -> x

--- a/src/Plugins/Monitors/Volume.hs
+++ b/src/Plugins/Monitors/Volume.hs
@@ -187,10 +187,10 @@ runVolumeWith opts mixerName controlName = do
 
     getFormatDB :: VolumeOpts -> Maybe Integer -> Monitor String
     getFormatDB _ Nothing = unavailable
-    getFormatDB opts (Just d) = formatDb opts d
+    getFormatDB opts' (Just d) = formatDb opts' d
 
     getFormatSwitch :: VolumeOpts -> Maybe Bool -> Monitor String
     getFormatSwitch _ Nothing = unavailable
-    getFormatSwitch opts (Just sw) = formatSwitch opts sw
+    getFormatSwitch opts' (Just sw) = formatSwitch opts' sw
 
     unavailable = getConfigValue naString

--- a/src/Signal.hs
+++ b/src/Signal.hs
@@ -88,26 +88,28 @@ withDeferSignals thing = do
 
   let signals =
         filter (not . flip inSignalSet reservedSignals)
-          [ sigHUP
-          -- , sigINT -- Handler already installed by GHC
-          , sigQUIT
-          , sigILL
-          , sigABRT
-          , sigFPE
-          , sigSEGV
-          --, sigPIPE -- Handler already installed by GHC
-          , sigALRM
+          [ sigQUIT
           , sigTERM
-          , sigBUS
-          , sigPOLL
-          , sigPROF
-          , sigSYS
-          , sigTRAP
-          , sigVTALRM
-          , sigXCPU
-          , sigXFSZ
-          -- , sigUSR1 -- Handled by setupSignalHandler
-          -- , sigUSR2 -- Handled by setupSignalHandler
+          --, sigINT -- Handler already installed by GHC
+          --, sigPIPE -- Handler already installed by GHC
+          --, sigUSR1 -- Handled by setupSignalHandler
+          --, sigUSR2 -- Handled by setupSignalHandler
+
+          -- One of the following appears to cause instability, see #360
+          --, sigHUP
+          --, sigILL
+          --, sigABRT
+          --, sigFPE
+          --, sigSEGV
+          --, sigALRM
+          --, sigBUS
+          --, sigPOLL
+          --, sigPROF
+          --, sigSYS
+          --, sigTRAP
+          --, sigVTALRM
+          --, sigXCPU
+          --, sigXFSZ
           ]
 
   for_ signals $ \s ->

--- a/test/Plugins/Monitors/AlsaSpec.hs
+++ b/test/Plugins/Monitors/AlsaSpec.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -Wall #-}
-module Plugins.Monitors.VolumeSpec
+module Plugins.Monitors.AlsaSpec
   ( main
   , spec
   ) where
@@ -7,7 +7,7 @@ module Plugins.Monitors.VolumeSpec
 import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Monad
-import Plugins.Monitors.Volume
+import Plugins.Monitors.Alsa
 import System.FilePath
 import System.IO
 import System.IO.Temp
@@ -20,22 +20,18 @@ main = hspec spec
 
 spec :: Spec
 spec = do
-  describe "Volume.getWaitMonitor" $
-    it "produces the expected timeline (using a fake alsactl)" $
-      runFakeAlsactlTest
+  describe "Alsa.getWaitMonitor" $
+    it "produces the expected timeline (using a fake alsactl)"
+       runFakeAlsactlTest
 
-  describe "Volume.parseOptsIncludingMonitorArgs" $ do
+  describe "Alsa.parseOptsIncludingMonitorArgs" $ do
     it "works with empty args" $ do
       opts <- parseOptsIncludingMonitorArgs []
-      refreshMode opts `shouldBe` RefreshModePoll
+      aoAlsaCtlPath opts `shouldBe` Nothing
 
-    it "parses --monitor" $ do
-      opts <- parseOptsIncludingMonitorArgs ["--", "--monitor"]
-      refreshMode opts `shouldBe` RefreshModeMonitor Nothing
-
-    it "parses --monitor=foo" $ do
-      opts <- parseOptsIncludingMonitorArgs ["--", "--monitor=foo"]
-      refreshMode opts `shouldBe` RefreshModeMonitor (Just "foo")
+    it "parses --alsactl=foo" $ do
+      opts <- parseOptsIncludingMonitorArgs ["--", "--alsactl=foo"]
+      aoAlsaCtlPath opts `shouldBe` Just "foo"
 
 
 runFakeAlsactlTest :: Expectation

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -187,7 +187,8 @@ executable xmobar
       mtl >= 2.1 && < 2.3,
       parsec == 3.1.*,
       parsec-numbers >= 0.1.0,
-      stm >= 2.3 && < 2.6
+      stm >= 2.3 && < 2.6,
+      async
 
     if impl(ghc < 8.0.2)
        -- Disable building with GHC before 8.0.2.

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -44,7 +44,8 @@ test-suite XmobarTest
         Plugins.Monitors.Swap, Plugins.Monitors.Thermal,
         Plugins.Monitors.ThermalZone, Plugins.Monitors.Top,
         Plugins.Monitors.Uptime,
-        Plugins.Monitors.Bright, Plugins.Monitors.CatInt
+        Plugins.Monitors.Bright, Plugins.Monitors.CatInt,
+        Plugins.Monitors.VolumeSpec
   build-depends:
     base >= 4.9.1.0 && < 4.13,
     hspec == 2.*,
@@ -62,7 +63,15 @@ test-suite XmobarTest
     mtl >= 2.1 && < 2.3,
     parsec == 3.1.*,
     parsec-numbers == 0.1.0,
-    stm >= 2.3 && < 2.6
+    stm >= 2.3 && < 2.6,
+    temporary,
+    async
+
+  if flag(with_alsa) || flag(all_extensions)
+      build-depends: alsa-mixer > 0.2.0.2
+      build-depends: alsa-core == 0.5.*
+      other-modules: Plugins.Monitors.Volume
+      cpp-options: -DALSA
 
 source-repository head
   type:      git

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -45,7 +45,8 @@ test-suite XmobarTest
         Plugins.Monitors.ThermalZone, Plugins.Monitors.Top,
         Plugins.Monitors.Uptime,
         Plugins.Monitors.Bright, Plugins.Monitors.CatInt,
-        Plugins.Monitors.VolumeSpec
+        Plugins.Monitors.CommonSpec
+
   build-depends:
     base >= 4.9.1.0 && < 4.13,
     hspec == 2.*,
@@ -69,8 +70,11 @@ test-suite XmobarTest
 
   if flag(with_alsa) || flag(all_extensions)
       build-depends: alsa-mixer > 0.2.0.2
-      build-depends: alsa-core == 0.5.*
+      build-depends: alsa-core == 0.5.*,
+                     process >= 1.4.3.0
       other-modules: Plugins.Monitors.Volume
+                     Plugins.Monitors.Alsa
+                     Plugins.Monitors.AlsaSpec
       cpp-options: -DALSA
 
 source-repository head
@@ -229,8 +233,10 @@ executable xmobar
 
     if flag(with_alsa) || flag(all_extensions)
        build-depends: alsa-mixer > 0.2.0.2
-       build-depends: alsa-core == 0.5.*
+       build-depends: alsa-core == 0.5.*,
+                      process >= 1.4.3.0
        other-modules: Plugins.Monitors.Volume
+                      Plugins.Monitors.Alsa
        cpp-options: -DALSA
 
     if flag(with_datezone) || flag(all_extensions)


### PR DESCRIPTION
This uses `alsactl monitor` for push/event-based updating instead of polling. Unless users encounter problems with this, I'd suggest making it the default in the future, since it reacts quicker and more smoothly, and avoids wasting cycles when nothing has changed :)

Side note: Duplicating the `if flag(...) ...` stuff in the test-suite stanza of the .cabal file is of course ugly. Maybe there should be an internal library, with the exe (stub) and the test-suite depending on it?

Fixes (kind-of) #290.