### PR TITLE
Alsa plugin: Restart alsactl if it quits (Fixes #376)

### DIFF
--- a/test/Xmobar/Plugins/Monitors/AlsaSpec.hs
+++ b/test/Xmobar/Plugins/Monitors/AlsaSpec.hs
@@ -58,7 +58,9 @@ runFakeAlsactlTest =
             waiterTaskIsRunning <- newEmptyMVar :: IO (MVar ())
             waiterTaskIsWaiting <- newEmptyMVar :: IO (MVar ())
 
-            withMonitorWaiter fifoPath (Just fakeAlsactlPath) $ \waitFunc -> do
+            let outputCallback msg = fail ("Did not expect the output callback to be invoked (message: "++show msg++")")
+
+            withMonitorWaiter fifoPath (Just fakeAlsactlPath) outputCallback $ \waitFunc -> do
 
               let addToTimeline e =  modifyMVar_ timeline (pure . (e :))
 


### PR DESCRIPTION
See also: #376

Is it safe to concurrently call the plugin output callback? Otherwise, I'd have to amend this because a concurrent write is theoretically possible if the main plugin thread is lagging and still processing an event from before `alsactl` crashed, while the reader thread writes "Restarting alsactl...".

I think it is safe because apparently, the callback ultimately comes from here:

```haskell
startCommand :: [...]
startCommand sig (com,s,ss)
[...]
    | otherwise = do var <- atomically $ newTVar is
                     let cb str = atomically $ writeTVar var (s ++ str ++ ss)
                     a1 <- async $ start com cb
                     a2 <- async $ trigger com $ maybe (return ())
                                                 (atomically . putTMVar sig)
                     return ([a1, a2], var)
    where is = s ++ "Updating..." ++ ss

```