### PR TITLE
Add `nix` section to stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -18,3 +18,16 @@ extra-deps:
 # - parsec-numbers-0.1.0
 # - libmpd-0.9.0.9
 # - alsa-mixer-0.3.0
+
+nix:
+    packages:
+      - alsaLib
+      - pkgconfig
+      - wirelesstools
+      - xorg.libX11
+      - xorg.libXext
+      - xorg.libXft
+      - xorg.libXpm
+      - xorg.libXrandr
+      - xorg.libXScrnSaver
+      - zlib


### PR DESCRIPTION
When building xmobar on NixOS (where stack's Nix integration is enabled by
default), this ensures that all required system libraries are available inside
the local build environment.

See https://docs.haskellstack.org/en/stable/nix_integration/ for details.