### PR TITLE
Touched up CoreTemp for better readability

### DIFF
--- a/src/Xmobar/Plugins/Monitors.hs
+++ b/src/Xmobar/Plugins/Monitors.hs
@@ -174,7 +174,7 @@ instance Exec Monitors where
     start (BatteryN s a r _) = runM a battConfig (runBatt' s) r
     start (Brightness a r) = runM a brightConfig runBright r
     start (CpuFreq a r) = runM a cpuFreqConfig runCpuFreq r
-    start (CoreTemp a r) = runM a coreTempConfig runCoreTemp r
+    start (CoreTemp a r) = startCoreTemp a r
     start (DiskU s a r) = runM a diskUConfig (runDiskU s) r
     start (DiskIO s a r) = startDiskIO s a r
     start (Uptime a r) = runM a uptimeConfig runUptime r

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -47,4 +47,4 @@ runCoreTemp _ = do
                        coreTempShow
 
 startCoreTemp :: [String] -> Int -> (String -> IO ()) -> IO ()
-startCoreTemp a r cb = runM a coreTempConfig runCoreTemp r cb
+startCoreTemp a = runM a coreTempConfig runCoreTemp

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -20,9 +20,8 @@ import Xmobar.Plugins.Monitors.Common
 -- | Generate Config with a default template and options.
 coreTempConfig :: IO MConfig
 coreTempConfig = mkMConfig coreTempTemplate coreTempOptions
-  where coreTempTemplate = "Temp: <total>°C"
-        coreTempOptions = map (("core" ++) . show) [0 :: Int ..] ++
-                          ["total"]
+  where coreTempTemplate = "Temp: <core0>°C"
+        coreTempOptions = map (("core" ++) . show) [0 :: Int ..]
 
 -- | FilePaths to read temperature from. Strings are seperated, where to
 -- insert numbers.

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -37,15 +37,15 @@ coreTempNormalize = (/ 1000)
 -- | Retrieves Monitor String holding the core temperatures.
 runCoreTemp :: [String] -> Monitor String
 runCoreTemp _ = do
-   confDecDigits <- getConfigValue decDigits
-   confNaString <- getConfigValue naString
-   let coreLabel = Nothing
-       coreTempShow = showDigits (max 0 confDecDigits)
-   checkedDataRetrieval confNaString
-                        coreTempFilePaths
-                        coreLabel
-                        coreTempNormalize
-                        coreTempShow
+  confDecDigits <- getConfigValue decDigits
+  confNaString <- getConfigValue naString
+  let coreLabel = Nothing
+      coreTempShow = showDigits (max 0 confDecDigits)
+  checkedDataRetrieval confNaString
+                       coreTempFilePaths
+                       coreLabel
+                       coreTempNormalize
+                       coreTempShow
 
 startCoreTemp :: [String] -> Int -> (String -> IO ()) -> IO ()
 startCoreTemp a r cb = runM a coreTempConfig runCoreTemp r cb


### PR DESCRIPTION
I want to implement a Plugin, which calculates the average core temperature.
I started with reading through the old CoreTemp Plugin and got to the conclusion, that I cannot calculate the average temperature, when the files are read by `checkedDataRetrieval`.

Along the way I made everything clear in the Plugin.

I would like your opinion on how to calculate an average temperature.
Is it necessary to manually read the files (like in the Cpu Plugin)?