### PR TITLE
MultiCoreTemp Plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1098,7 +1098,8 @@ more than one battery.
 
 - Aliases to `multicoretemp`
 - Args: default monitor arguments, plus:
-  - `--temp-icon-pattern`: dynamic string for overall cpu load in `maxipat` and `avgipat`.
+  - `--max-icon-pattern`: dynamic string for overall cpu load in `maxipat`.
+  - `--avg-icon-pattern`: dynamic string for overall cpu load in `avgipat`.
   - `--mintemp`: temperature in degree Celsius, that sets the lower limit for percentage calculation.
   - `--maxtemp`: temperature in degree Celsius, that sets the upper limit for percentage calculation.
 - Thresholds refer to temperature in degree Celsius

--- a/readme.md
+++ b/readme.md
@@ -1094,6 +1094,30 @@ more than one battery.
                        "-L", "40", "-H", "60",
                        "-l", "lightblue", "-n", "gray90", "-h", "red"] 50
 
+### `MultiCoreTemp Args RefreshRate`
+
+- Aliases to `multicoretemp`
+- Args: default monitor arguments, plus:
+  - `--temp-icon-pattern`: dynamic string for overall cpu load in `maxipat` and `avgipat`.
+  - `--mintemp`: temperature in degree Celsius, that sets the lower limit for percentage calculation.
+  - `--maxtemp`: temperature in degree Celsius, that sets the upper limit for percentage calculation.
+- Thresholds refer to temperature in degree Celsius
+- Variables that can be used with the `-t`/`--template` argument:
+            `max`, `maxpc`, `maxbar`, `maxvbar`, `maxipat`,
+            `avg`, `avgpc`, `avgbar`, `avgvbar`, `avgipat`,
+            `core0`, `core1`, ..., `coreN`
+
+  The *pc, *bar, *vbar and *ipat variables are showing percentages on the scale
+  defined by `--mintemp` and `--maxtemp`.
+- Default template: `Temp: <max>°C - <maxpc>%`
+- This monitor requires coretemp module to be loaded in kernel
+- Example:
+
+         Run CoreTemp ["-t", "Temp: <max>°C | <maxpc>%",
+                       "-L", "60", "-H", "80",
+                       "-l", "green", "-n", "yellow", "-h", "red"
+                       "--", "--mintemp", "20", "--maxtemp", "100"] 50
+
 ### `Volume Mixer Element Args RefreshRate`
 
 - Aliases to the mixer name and element name separated by a colon. Thus,

--- a/readme.md
+++ b/readme.md
@@ -1109,14 +1109,15 @@ more than one battery.
 
   The *pc, *bar, *vbar and *ipat variables are showing percentages on the scale
   defined by `--mintemp` and `--maxtemp`.
+  The max* and avg* variables to the highest and the average core temperature.
 - Default template: `Temp: <max>°C - <maxpc>%`
 - This monitor requires coretemp module to be loaded in kernel
 - Example:
 
-         Run CoreTemp ["-t", "Temp: <max>°C | <maxpc>%",
-                       "-L", "60", "-H", "80",
-                       "-l", "green", "-n", "yellow", "-h", "red"
-                       "--", "--mintemp", "20", "--maxtemp", "100"] 50
+         Run MultiCoreTemp ["-t", "Temp: <avg>°C | <avgpc>%",
+                            "-L", "60", "-H", "80",
+                            "-l", "green", "-n", "yellow", "-h", "red"
+                            "--", "--mintemp", "20", "--maxtemp", "100"] 50
 
 ### `Volume Mixer Element Args RefreshRate`
 

--- a/src/Xmobar/Plugins/Monitors.hs
+++ b/src/Xmobar/Plugins/Monitors.hs
@@ -177,7 +177,7 @@ instance Exec Monitors where
     start (BatteryN s a r _) = runM a battConfig (runBatt' s) r
     start (Brightness a r) = runM a brightConfig runBright r
     start (CpuFreq a r) = runM a cpuFreqConfig runCpuFreq r
-    start (CoreTemp a r) = startCoreTemp a r
+    start (CoreTemp a r) = runM a coreTempConfig runCoreTemp r
     start (MultiCoreTemp a r) = startMultiCoreTemp a r
     start (DiskU s a r) = runM a diskUConfig (runDiskU s) r
     start (DiskIO s a r) = startDiskIO s a r

--- a/src/Xmobar/Plugins/Monitors.hs
+++ b/src/Xmobar/Plugins/Monitors.hs
@@ -174,7 +174,7 @@ instance Exec Monitors where
     start (BatteryN s a r _) = runM a battConfig (runBatt' s) r
     start (Brightness a r) = runM a brightConfig runBright r
     start (CpuFreq a r) = runM a cpuFreqConfig runCpuFreq r
-    start (CoreTemp a r) = runM a coreTempConfig runCoreTemp r
+    start (CoreTemp a r) = startCoreTemp a r
     start (DiskU s a r) = runM a diskUConfig (runDiskU s) r
     start (DiskIO s a r) = startDiskIO s a r
     start (Uptime a r) = runM a uptimeConfig runUptime r

--- a/src/Xmobar/Plugins/Monitors.hs
+++ b/src/Xmobar/Plugins/Monitors.hs
@@ -34,6 +34,7 @@ import Xmobar.Plugins.Monitors.Thermal
 import Xmobar.Plugins.Monitors.ThermalZone
 import Xmobar.Plugins.Monitors.CpuFreq
 import Xmobar.Plugins.Monitors.CoreTemp
+import Xmobar.Plugins.Monitors.MultiCoreTemp
 import Xmobar.Plugins.Monitors.Disk
 import Xmobar.Plugins.Monitors.Top
 import Xmobar.Plugins.Monitors.Uptime
@@ -72,6 +73,7 @@ data Monitors = Network      Interface   Args Rate
               | Brightness   Args        Rate
               | CpuFreq      Args        Rate
               | CoreTemp     Args        Rate
+              | MultiCoreTemp Args       Rate
               | TopProc      Args        Rate
               | TopMem       Args        Rate
               | Uptime       Args        Rate
@@ -132,6 +134,7 @@ instance Exec Monitors where
     alias (TopProc _ _) = "top"
     alias (TopMem _ _) = "topmem"
     alias (CoreTemp _ _) = "coretemp"
+    alias (MultiCoreTemp _ _) = "multicoretemp"
     alias DiskU {} = "disku"
     alias DiskIO {} = "diskio"
     alias (Uptime _ _) = "uptime"
@@ -175,6 +178,7 @@ instance Exec Monitors where
     start (Brightness a r) = runM a brightConfig runBright r
     start (CpuFreq a r) = runM a cpuFreqConfig runCpuFreq r
     start (CoreTemp a r) = startCoreTemp a r
+    start (MultiCoreTemp a r) = startMultiCoreTemp a r
     start (DiskU s a r) = runM a diskUConfig (runDiskU s) r
     start (DiskIO s a r) = startDiskIO s a r
     start (Uptime a r) = runM a uptimeConfig runUptime r

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -27,7 +27,7 @@ coreTempConfig = mkMConfig coreTempTemplate coreTempOptions
 -- insert numbers.
 coreTempFilePaths :: [[FilePath]]
 coreTempFilePaths = [ ["/sys/bus/platform/devices/coretemp." , "/temp" , "_input"]
-                    , ["/sys/bus/platform/devices/coretemp.", "/hwmon/hwmon", "/temp", "_input"]
+                    , ["/sys/bus/platform/devices/coretemp." , "/hwmon/hwmon" , "/temp" , "_input"]
                     ]
 
 coreTempNormalize :: Double -> Double

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -65,14 +65,14 @@ cTConfig = mkMConfig cTTemplate cTOptions
   where cTTemplate = "Temp: <max>°C - <maxpc>%"
         cTOptions = [ "max" , "maxpc" , "maxbar" , "maxvbar" , "maxipat"
                     , "avg" , "avgpc" , "avgbar" , "avgvbar" , "avgipat"
-                    ] ++ (map (("core" ++) . show) [0 :: Int ..])
+                    ] ++ map (("core" ++) . show) [0 :: Int ..]
 
 -- | Returns the first coretemp.N path found.
 coretempPath :: IO String
 coretempPath = do xs <- filterM doesDirectoryExist ps
                   let x = head xs
                   return x
-  where ps = [ "/sys/bus/platform/devices/coretemp." ++ (show (x :: Int)) ++ "/" | x <- [0..9] ]
+  where ps = [ "/sys/bus/platform/devices/coretemp." ++ show (x :: Int) ++ "/" | x <- [0..9] ]
 
 -- | Returns the first hwmonN path found.
 hwmonPath :: IO String
@@ -101,8 +101,7 @@ labelToCore = (++ "input") . reverse . drop 5 . reverse
 -- | Reads core-temperatures as data from the system.
 cTData :: IO [Float]
 cTData = do fps <- corePaths
-            fs <- traverse readSingleFile fps
-            return fs
+            traverse readSingleFile fps
   where readSingleFile :: FilePath -> IO Float
         readSingleFile s = do a <- readFile s
                               return $ parseContent a
@@ -122,7 +121,7 @@ formatCT opts cTs = do let CTOpts { mintemp = minT
                                   , maxtemp = maxT } = opts
                            domainT = maxT - minT
                            maxCT = maximum cTs
-                           avgCT = sum cTs / (fromIntegral $ length cTs)
+                           avgCT = sum cTs / fromIntegral (length cTs)
                            calcPc t = (t - minT) / domainT
                            maxCTPc = calcPc maxCT
                            avgCTPc = calcPc avgCT
@@ -130,13 +129,13 @@ formatCT opts cTs = do let CTOpts { mintemp = minT
                        cs <- traverse showTempWithColors cTs
 
                        m <- showTempWithColors maxCT
-                       mp <- showWithColors' (show $ (round $ 100*maxCTPc :: Int)) maxCT
+                       mp <- showWithColors' (show (round (100*maxCTPc) :: Int)) maxCT
                        mb <- showPercentBar maxCT maxCTPc
                        mv <- showVerticalBar maxCT maxCTPc
                        mi <- showIconPattern (loadIconPattern opts) maxCTPc
 
                        a <- showTempWithColors avgCT
-                       ap <- showWithColors' (show $ (round $ 100*avgCTPc :: Int)) avgCT
+                       ap <- showWithColors' (show (round (100*avgCTPc) :: Int)) avgCT
                        ab <- showPercentBar avgCT avgCTPc
                        av <- showVerticalBar avgCT avgCTPc
                        ai <- showIconPattern (loadIconPattern opts) avgCTPc
@@ -150,7 +149,7 @@ formatCT opts cTs = do let CTOpts { mintemp = minT
 
 
 runCT :: [String] -> Monitor String
-runCT argv = do cTs <- io $ parseCT
+runCT argv = do cTs <- io parseCT
                 opts <- io $ parseOpts argv
                 l <- formatCT opts cTs
                 parseTemplate l

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -68,31 +68,38 @@ cTConfig = mkMConfig cTTemplate cTOptions
                     , "avg" , "avgpc" , "avgbar" , "avgvbar" , "avgipat"
                     ] ++ (map (("core" ++) . show) [0 :: Int ..])
 
+-- | Returns the first coretemp.N path found.
 coretempPath :: IO String
 coretempPath = do xs <- filterM doesDirectoryExist ps
                   let x = head xs
                   return x
   where ps = [ "/sys/bus/platform/devices/coretemp." ++ (show (x :: Int)) ++ "/" | x <- [0..9] ]
 
+-- | Returns the first hwmonN path found.
 hwmonPath :: IO String
 hwmonPath = do p <- coretempPath
                xs <- filterM doesDirectoryExist [ p ++ "hwmon/hwmon" ++ show (x :: Int) ++ "/" | x <- [0..9] ]
                let x = head xs
                return x
 
+-- | Checks Labels, if they refer to a core and returns Strings of core-
+-- temperatures.
 corePaths :: IO [String]
 corePaths = do p <- hwmonPath
                ls <- filterM doesFileExist [ p ++ "temp" ++ show (x :: Int) ++ "_label" | x <- [0..9] ]
                cls <- filterM isLabelFromCore ls
                return $ map labelToCore cls
 
+-- | Checks if Label refers to a core.
 isLabelFromCore :: FilePath -> IO Bool
 isLabelFromCore p = do a <- readFile p
                        return $ take 4 a == "Core"
 
+-- | Transform a path to Label to a path to core-temperature.
 labelToCore :: FilePath -> FilePath
 labelToCore = (++ "input") . reverse . drop 5 . reverse
 
+-- | Reads core-temperatures as data from the system.
 cTData :: IO [Float]
 cTData = do fps <- corePaths
             fs <- traverse readSingleFile fps
@@ -103,11 +110,14 @@ cTData = do fps <- corePaths
           where parseContent :: String -> Float
                 parseContent = read . head . lines
 
+-- | Transforms data of temperatures into temperatures of degree Celsius.
 parseCT :: IO [Float]
 parseCT = do rawCTs <- cTData
              let normalizedCTs = map (/ 1000) rawCTs :: [Float]
              return normalizedCTs
 
+-- | Performs calculation for maximum and average.
+-- Sets up Bars and Values to be printed.
 formatCT :: CTOpts -> [Float] -> Monitor [String]
 formatCT opts cTs = do let CTOpts { mintemp = minT
                                   , maxtemp = maxT } = opts

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -47,4 +47,4 @@ runCoreTemp _ = do
                        coreTempShow
 
 startCoreTemp :: [String] -> Int -> (String -> IO ()) -> IO ()
-startCoreTemp a r cb = runM a coreTempConfig runCoreTemp r cb
+startCoreTemp a = runM a coreTempConfig runCoreTemp

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -1,0 +1,43 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Plugins.Monitors.CoreTemp
+-- Copyright   :  (c) Juraj Hercek
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  Juraj Hercek <juhe_haskell@hck.sk>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- A core temperature monitor for Xmobar
+--
+-----------------------------------------------------------------------------
+
+module Xmobar.Plugins.Monitors.CoreTemp where
+
+import Xmobar.Plugins.Monitors.Common
+
+import Data.Char (isDigit)
+
+-- |
+-- Core temperature default configuration. Default template contains only one
+-- core temperature, user should specify custom template in order to get more
+-- core frequencies.
+coreTempConfig :: IO MConfig
+coreTempConfig = mkMConfig
+       "Temp: <core0>C" -- template
+       (map ((++) "core" . show) [0 :: Int ..]) -- available
+                                                -- replacements
+
+-- |
+-- Function retrieves monitor string holding the core temperature
+-- (or temperatures)
+runCoreTemp :: [String] -> Monitor String
+runCoreTemp _ = do
+   dn <- getConfigValue decDigits
+   failureMessage <- getConfigValue naString
+   let path = ["/sys/bus/platform/devices/coretemp.", "/temp", "_input"]
+       path' = ["/sys/bus/platform/devices/coretemp.", "/hwmon/hwmon", "/temp", "_input"]
+       lbl  = Just ("_label", read . dropWhile (not . isDigit))
+       divisor = 1e3 :: Double
+       show' = showDigits (max 0 dn)
+   checkedDataRetrieval failureMessage [path, path'] lbl (/divisor) show'

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -123,18 +123,19 @@ formatCT opts cTs = do let CTOpts { mintemp = minT
                            domainT = maxT - minT
                            maxCT = maximum cTs
                            avgCT = sum cTs / (fromIntegral $ length cTs)
-                           maxCTPc = (maxCT - minT) / domainT
-                           avgCTPc = (avgCT - minT) / domainT
+                           calcPc t = (t - minT) / domainT
+                           maxCTPc = calcPc maxCT
+                           avgCTPc = calcPc avgCT
 
-                       cs <- showPercentsWithColors cTs
+                       cs <- traverse showTempWithColors cTs
 
-                       m <- showWithColors (show . (round :: Float -> Int)) maxCT
+                       m <- showTempWithColors maxCT
                        mp <- showWithColors' (show $ (round $ 100*maxCTPc :: Int)) maxCT
                        mb <- showPercentBar maxCT maxCTPc
                        mv <- showVerticalBar maxCT maxCTPc
                        mi <- showIconPattern (loadIconPattern opts) maxCTPc
 
-                       a <- showWithColors (show . (round :: Float -> Int)) avgCT
+                       a <- showTempWithColors avgCT
                        ap <- showWithColors' (show $ (round $ 100*avgCTPc :: Int)) avgCT
                        ab <- showPercentBar avgCT avgCTPc
                        av <- showVerticalBar avgCT avgCTPc
@@ -144,6 +145,9 @@ formatCT opts cTs = do let CTOpts { mintemp = minT
                            as = [ a , ap , ab , av , ai ]
 
                        return (ms ++ as ++ cs)
+  where showTempWithColors :: Float -> Monitor String
+        showTempWithColors = showWithColors (show . (round :: Float -> Int))
+
 
 runCT :: [String] -> Monitor String
 runCT argv = do cTs <- io $ parseCT

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -2,7 +2,6 @@
 -- |
 -- Module      :  Plugins.Monitors.CoreTemp
 -- Copyright   :  (c) 2019 Felix Springer
---                (c) Juraj Hercek
 -- License     :  BSD-style (see LICENSE)
 --
 -- Maintainer  :  Felix Springer <felixspringer149@gmail.com>

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -16,19 +16,24 @@
 module Xmobar.Plugins.Monitors.CoreTemp (startCoreTemp) where
 
 import Xmobar.Plugins.Monitors.Common
+import Control.Monad (filterM)
 import System.Console.GetOpt
+import System.Directory (doesDirectoryExist)
 
+-- | Declare Options.
 data CTOpts = CTOpts { loadIconPattern :: Maybe IconPattern
                         , mintemp :: Float
                         , maxtemp :: Float
                         }
 
+-- | Set default Options.
 defaultOpts :: CTOpts
 defaultOpts = CTOpts { loadIconPattern = Nothing
                      , mintemp = 0
-                     , maxtemp = 1
+                     , maxtemp = 100
                      }
 
+-- | Apply configured Options.
 options :: [OptDescr (CTOpts -> CTOpts)]
 options = [ Option [] ["load-icon-pattern"]
               (ReqArg
@@ -37,16 +42,17 @@ options = [ Option [] ["load-icon-pattern"]
               ""
           , Option [] ["mintemp"]
               (ReqArg
-                (\ arg opts -> opts { mintemp = read arg / 100 })
+                (\ arg opts -> opts { mintemp = read arg })
                 "")
               ""
           , Option [] ["maxtemp"]
               (ReqArg
-                (\ arg opts -> opts { maxtemp = read arg / 100 })
+                (\ arg opts -> opts { maxtemp = read arg })
                 "")
               ""
           ]
 
+-- | Parse Arguments and apply them to Options.
 parseOpts :: [String] -> IO CTOpts
 parseOpts argv = case getOpt Permute options argv of
                    (opts , _ , []  ) -> return $ foldr id defaultOpts opts
@@ -55,21 +61,44 @@ parseOpts argv = case getOpt Permute options argv of
 -- | Generate Config with a default template and options.
 cTConfig :: IO MConfig
 cTConfig = mkMConfig cTTemplate cTOptions
-  where cTTemplate = "Temp: <max>°C"
-        cTOptions = [ "bar" , "vbar" , "ipat" , "max" , "maxpc" , "avg" , "avgpc" ] ++
-                      (map (("core" ++) . show) [0 :: Int ..])
+  where cTTemplate = "Temp: <max>°C - <maxpc>%"
+        cTOptions = [ "max" , "maxpc" , "maxbar" , "maxvbar" , "maxipat"
+                    , "avg" , "avgpc" , "avgbar" , "avgvbar" , "avgipat"
+                    ] ++ (map (("core" ++) . show) [0 :: Int ..])
 
-cTFilePath :: FilePath
-cTFilePath = "/sys/bus/platform/devices/coretemp.0/hwmon/hwmon1/temp2_input"
+coretempPath :: IO String
+coretempPath = do xs <- filterM doesDirectoryExist ps
+                  let x = head xs
+                  return x
+  where ps = [ "/sys/bus/platform/devices/coretemp." ++ (show (x :: Int)) | x <- [0..9] ]
+
+hwmonPath :: IO String
+hwmonPath = do p <- coretempPath
+               xs <- filterM doesDirectoryExist [ p ++ "/hwmon/hwmon" ++ show (x :: Int) | x <- [0..9] ]
+               let x = head xs
+               return x
+
+corePaths :: IO [String]
+corePaths = do p <- hwmonPath
+               return [ p ]
+
+cTFilePaths = [ "/sys/bus/platform/devices/coretemp.0/hwmon/hwmon1/temp2_input"
+              , "/sys/bus/platform/devices/coretemp.0/hwmon/hwmon1/temp3_input"
+              , "/sys/bus/platform/devices/coretemp.0/hwmon/hwmon1/temp4_input"
+              , "/sys/bus/platform/devices/coretemp.0/hwmon/hwmon1/temp5_input"
+              ]
 
 cTData :: IO [Float]
-cTData = do a <- readFile cTFilePath
-            return $ [ parseContent a ]
-  where parseContent = read . head . lines :: String -> Float
+cTData = traverse readSingleFile cTFilePaths
+  where readSingleFile :: FilePath -> IO Float
+        readSingleFile s = do a <- readFile s
+                              return $ parseContent a
+          where parseContent :: String -> Float
+                parseContent = read . head . lines
 
 parseCT :: IO [Float]
 parseCT = do rawCTs <- cTData
-             let normalizedCTs = map ((/ 100000)) rawCTs :: [Float]
+             let normalizedCTs = map (/ 1000) rawCTs :: [Float]
              return normalizedCTs
 
 formatCT :: CTOpts -> [Float] -> Monitor [String]
@@ -81,19 +110,24 @@ formatCT opts cTs = do let CTOpts { mintemp = minT
                            maxCTPc = (maxCT - minT) / domainT
                            avgCTPc = (avgCT - minT) / domainT
 
-                       cTShows <- showPercentsWithColors cTs
-                       cTBar <- showPercentBar (100 * maxCTPc) maxCTPc
-                       cTVBar <- showVerticalBar (100 * maxCTPc) maxCTPc
-                       cTIcon <- showIconPattern (loadIconPattern opts) maxCTPc
-                       maxCTShow <- showPercentWithColors maxCT
-                       maxCTPcShow <- showPercentWithColors maxCTPc
-                       avgCTShow <- showPercentWithColors avgCT
-                       avgCTPcShow <- showPercentWithColors avgCTPc
+                       cs <- showPercentsWithColors cTs
 
-                       return (cTBar : cTVBar : cTIcon :
-                         maxCTShow : maxCTPcShow :
-                         avgCTShow : avgCTPcShow :
-                         cTShows)
+                       m <- showWithColors (show . (round :: Float -> Int)) maxCT
+                       mp <- showWithColors' (show $ (round $ 100*maxCTPc :: Int)) maxCT
+                       mb <- showPercentBar maxCT maxCTPc
+                       mv <- showVerticalBar maxCT maxCTPc
+                       mi <- showIconPattern (loadIconPattern opts) maxCTPc
+
+                       a <- showWithColors (show . (round :: Float -> Int)) avgCT
+                       ap <- showWithColors' (show $ (round $ 100*avgCTPc :: Int)) avgCT
+                       ab <- showPercentBar avgCT avgCTPc
+                       av <- showVerticalBar avgCT avgCTPc
+                       ai <- showIconPattern (loadIconPattern opts) avgCTPc
+
+                       let ms = [ m , mp , mb , mv , mi ]
+                           as = [ a , ap , ab , av , ai ]
+
+                       return (ms ++ as ++ cs)
 
 runCT :: [String] -> Monitor String
 runCT argv = do cTs <- io $ parseCT
@@ -103,3 +137,8 @@ runCT argv = do cTs <- io $ parseCT
 
 startCoreTemp :: [String] -> Int -> (String -> IO ()) -> IO ()
 startCoreTemp a = runM a cTConfig runCT
+
+---
+
+--showTemps :: [Float] -> Monitor [String]
+--showTemps fs = do fstrs <- mapM 

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -20,9 +20,8 @@ import Xmobar.Plugins.Monitors.Common
 -- | Generate Config with a default template and options.
 coreTempConfig :: IO MConfig
 coreTempConfig = mkMConfig coreTempTemplate coreTempOptions
-  where coreTempTemplate = "Temp: <total>°C"
-        coreTempOptions = map (("core" ++) . show) [0 :: Int ..] ++
-                          ["total"]
+  where coreTempTemplate = "Temp: <core0>°C"
+        coreTempOptions = map (("core" ++) . show) [0 :: Int ..]
 
 -- | FilePaths to read temperature from. Strings are seperated, where to
 -- insert numbers.

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -37,15 +37,15 @@ coreTempNormalize = (/ 1000)
 -- | Retrieves Monitor String holding the core temperatures.
 runCoreTemp :: [String] -> Monitor String
 runCoreTemp _ = do
-   confDecDigits <- getConfigValue decDigits
-   confNaString <- getConfigValue naString
-   let coreLabel = Nothing
-       coreTempShow = showDigits (max 0 confDecDigits)
-   checkedDataRetrieval confNaString
-                        coreTempFilePaths
-                        coreLabel
-                        coreTempNormalize
-                        coreTempShow
+  confDecDigits <- getConfigValue decDigits
+  confNaString <- getConfigValue naString
+  let coreLabel = Nothing
+      coreTempShow = showDigits (max 0 confDecDigits)
+  checkedDataRetrieval confNaString
+                       coreTempFilePaths
+                       coreLabel
+                       coreTempNormalize
+                       coreTempShow
 
 startCoreTemp :: [String] -> Int -> (String -> IO ()) -> IO ()
 startCoreTemp a r cb = runM a coreTempConfig runCoreTemp r cb

--- a/src/Xmobar/Plugins/Monitors/MultiCoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/MultiCoreTemp.hs
@@ -22,23 +22,30 @@ import System.Directory ( doesDirectoryExist
                         )
 
 -- | Declare Options.
-data CTOpts = CTOpts { loadIconPattern :: Maybe IconPattern
+data CTOpts = CTOpts { maxIconPattern :: Maybe IconPattern
+                     , avgIconPattern :: Maybe IconPattern
                      , mintemp :: Float
                      , maxtemp :: Float
                      }
 
 -- | Set default Options.
 defaultOpts :: CTOpts
-defaultOpts = CTOpts { loadIconPattern = Nothing
+defaultOpts = CTOpts { maxIconPattern = Nothing
+                     , avgIconPattern = Nothing
                      , mintemp = 0
                      , maxtemp = 100
                      }
 
 -- | Apply configured Options.
 options :: [OptDescr (CTOpts -> CTOpts)]
-options = [ Option [] ["load-icon-pattern"]
+options = [ Option [] ["max-icon-pattern"]
               (ReqArg
-                (\ arg opts -> opts { loadIconPattern = Just $ parseIconPattern arg })
+                (\ arg opts -> opts { maxIconPattern = Just $ parseIconPattern arg })
+                "")
+              ""
+          , Option [] ["avg-icon-pattern"]
+              (ReqArg
+                (\ arg opts -> opts { avgIconPattern = Just $ parseIconPattern arg })
                 "")
               ""
           , Option [] ["mintemp"]
@@ -132,13 +139,13 @@ formatCT opts cTs = do let CTOpts { mintemp = minT
                        mp <- showWithColors' (show (round (100*maxCTPc) :: Int)) maxCT
                        mb <- showPercentBar maxCT maxCTPc
                        mv <- showVerticalBar maxCT maxCTPc
-                       mi <- showIconPattern (loadIconPattern opts) maxCTPc
+                       mi <- showIconPattern (maxIconPattern opts) maxCTPc
 
                        a <- showTempWithColors avgCT
                        ap <- showWithColors' (show (round (100*avgCTPc) :: Int)) avgCT
                        ab <- showPercentBar avgCT avgCTPc
                        av <- showVerticalBar avgCT avgCTPc
-                       ai <- showIconPattern (loadIconPattern opts) avgCTPc
+                       ai <- showIconPattern (avgIconPattern opts) avgCTPc
 
                        let ms = [ m , mp , mb , mv , mi ]
                            as = [ a , ap , ab , av , ai ]

--- a/src/Xmobar/Plugins/Monitors/MultiCoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/MultiCoreTemp.hs
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------
 -- |
--- Module      :  Plugins.Monitors.CoreTemp
+-- Module      :  Plugins.Monitors.MultiCoreTemp
 -- Copyright   :  (c) 2019 Felix Springer
 -- License     :  BSD-style (see LICENSE)
 --
@@ -12,7 +12,7 @@
 --
 -----------------------------------------------------------------------------
 
-module Xmobar.Plugins.Monitors.CoreTemp (startCoreTemp) where
+module Xmobar.Plugins.Monitors.MultiCoreTemp (startMultiCoreTemp) where
 
 import Xmobar.Plugins.Monitors.Common
 import Control.Monad (filterM)
@@ -23,9 +23,9 @@ import System.Directory ( doesDirectoryExist
 
 -- | Declare Options.
 data CTOpts = CTOpts { loadIconPattern :: Maybe IconPattern
-                        , mintemp :: Float
-                        , maxtemp :: Float
-                        }
+                     , mintemp :: Float
+                     , maxtemp :: Float
+                     }
 
 -- | Set default Options.
 defaultOpts :: CTOpts
@@ -154,5 +154,5 @@ runCT argv = do cTs <- io parseCT
                 l <- formatCT opts cTs
                 parseTemplate l
 
-startCoreTemp :: [String] -> Int -> (String -> IO ()) -> IO ()
-startCoreTemp a = runM a cTConfig runCT
+startMultiCoreTemp :: [String] -> Int -> (String -> IO ()) -> IO ()
+startMultiCoreTemp a = runM a cTConfig runCT

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -143,6 +143,7 @@ library
                    Xmobar.Plugins.Monitors.Cpu,
                    Xmobar.Plugins.Monitors.Disk,
                    Xmobar.Plugins.Monitors.Mem,
+                   Xmobar.Plugins.Monitors.MultiCoreTemp,
                    Xmobar.Plugins.Monitors.MultiCpu,
                    Xmobar.Plugins.Monitors.Net,
                    Xmobar.Plugins.Monitors.Swap,


### PR DESCRIPTION
This plugin reads the information mainly the same way as the old CoreTemp, but it allows using `<bar>`, `<vbar>` and `<ipat>` for the maximum and average values.

I had to rewrite a lot, as the functions in `Plugins/Common` were not sufficient.
I can also write a Readme entry for it if you want to take it into the master branch.