### PR TITLE
Write error log to data dir, not conf dir

### DIFF
--- a/examples/build
+++ b/examples/build
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+# An example build script that directs ghc to use a temporary directory for its
+# intermediate files instead of writing them into XMOBAR_CONFIG_DIR.  This
+# allows using a read-only XMOBAR_CONFIG_DIR.  To use this script, place it in
+# XMOBAR_CONFIG_DIR and call it "build".
+
+bin=$1
+object_dir=$(mktemp -d)
+
+default_build_args=(--make xmobar.hs -i -ilib -fforce-recomp -main-is main -v0 -o "$bin" -threaded -rtsopts -with-rtsopts -V0) # From src/Xmobar/App/Compile.hs
+extra_build_args=(-odir "$object_dir" -hidir "$object_dir")
+
+ghc "${default_build_args[@]}" "${extra_build_args[@]}"
+status=$?
+rm -r "$object_dir"
+exit $status

--- a/src/Xmobar/App/Compile.hs
+++ b/src/Xmobar/App/Compile.hs
@@ -131,13 +131,13 @@ trace verb msg = when verb (liftIO $ hPutStrLn stderr msg)
 --
 -- 'False' is returned if there are compilation errors.
 --
-recompile :: MonadIO m => String -> String -> Bool -> Bool -> m Bool
-recompile dir execName force verb = liftIO $ do
-    let bin  = dir </> execName
-        err  = dir </> (execName ++ ".errors")
-        src  = dir </> (execName ++ ".hs")
-        lib  = dir </> "lib"
-        script = dir </> "build"
+recompile :: MonadIO m => String -> String -> String -> Bool -> Bool -> m Bool
+recompile confDir dataDir execName force verb = liftIO $ do
+    let bin  = confDir </> execName
+        err  = dataDir </> (execName ++ ".errors")
+        src  = confDir </> (execName ++ ".hs")
+        lib  = confDir </> "lib"
+        script = confDir </> "build"
     useScript <- checkBuildScript verb script
     sc <- if useScript || force
           then return True
@@ -149,8 +149,8 @@ recompile dir execName force verb = liftIO $ do
                     \errHandle ->
                       waitForProcess =<<
                         if useScript
-                        then runScript script bin dir errHandle
-                        else runGHC bin dir errHandle
+                        then runScript script bin confDir errHandle
+                        else runGHC bin confDir errHandle
         installSignalHandlers
         if status == ExitSuccess
             then trace verb "Xmobar recompilation process exited with success!"


### PR DESCRIPTION
Write xmobar.errors to XMOBAR_DATA_DIR, not XMOBAR_CONFIG_DIR.  This
allows XMOBAR_CONFIG_DIR to be read-only.  This brings xmobar into
alignment with how xmonad manages its analogous directories (before this
change, a read-only DATA dir worked with xmonad but not with xmobar).