### PR TITLE
Display additional string depending on battery status

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@ _New features_
   - New option `--contiguous-icons` for `MultiCpu` to draw icons
     without padding (see [issue #388]).
   - New version of libmpd (0.9.0.10), thanks to John Tyree
+  - New options `--lows`, `--mediums`, and `--highs` for `Battery`
+    to display an additional string depending on battery level.
 
 [issue #388]: https://github.com/jaor/xmobar/issues/388
 

--- a/readme.md
+++ b/readme.md
@@ -917,6 +917,13 @@ specification, such as `("clear", "<icon=weather-clear.xbm/>")`.
     when AC is "off" in `leftipat`.
   - `--idle-icon-pattern`: dynamic string for current battery charge
     when AC is "idle" in `leftipat`.
+  - `--lows`: string for AC "off" status and power lower than the `-L`
+    threshold (default: "")
+  - `--mediums`: string for AC "off" status and power lower than the `-H`
+    threshold (default: "")
+  - `--high`: string for AC "off" status and power higher than the `-H`
+    threshold (default: "")
+
 
 - Variables that can be used with the `-t`/`--template` argument:
 	    `left`, `leftbar`, `leftvbar`, `leftipat`, `timeleft`, `watts`, `acstatus`


### PR DESCRIPTION
This extends the `Battery` plugin by three new arguments: `--lows`, `--mediums`, and `--highs` (I could not think of any mnemonically sound one character aliases for these). They can be used to display an additional string, depending on the current battery level (as set by `-L` and `-H`).  It be displayed in front of the `--off` string. All three values default to `""`, so as to not interfere with any configuration not explicitly setting them.

Usage example:
```
Config { font = "xft:FontAwesome:antialias=true:hinting=true:size=9,sans"
       , commands = [ Run Battery
                          [ "--template", "<acstatus>"
                          , "--"
                          , "--lowt"    , "15"
                          , "--hight"   , "70"
                          , "--lows"    , ""
                          , "--mediums" , ""
                          , "--highs"   , ""
                          , "--off"     , "  <left>% (<timeleft>)"
                          ] 100
                    ]
       , template = "%battery%"
       }
```