### PR TITLE
Plugins/Kbd: ignore "terminate" layout token

### DIFF
--- a/src/Xmobar/Plugins/Kbd.hs
+++ b/src/Xmobar/Plugins/Kbd.hs
@@ -27,7 +27,7 @@ import Xmobar.System.Kbd
 
 -- 'Bad' prefixes of layouts
 noLaySymbols :: [String]
-noLaySymbols = ["group", "inet", "ctr", "pc", "ctrl"]
+noLaySymbols = ["group", "inet", "ctr", "pc", "ctrl", "terminate"]
 
 
 -- splits the layout string into the actual layouts


### PR DESCRIPTION
This fixes printing of Kbd from terminate(ctrl_alt_bksp)
to RU as expected given this config stanza:
      , Run Kbd [("us", "US"), ("ru", "RU")]

and this layout:

% setxkbmap  -print
xkb_keymap {
	xkb_keycodes  { include "xfree86+aliases(qwerty)"	};
	xkb_types     { include "complete"	};
	xkb_compat    { include "complete"	};
	xkb_symbols   { include "pc+us+inet(pc105)+terminate(ctrl_alt_bksp)+ru:2+capslock(grouplock)"	};
	xkb_geometry  { include "pc(pc105)"	};
};