### PR TITLE
Display additional string based on volume level

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ _New features_
 
   - New options `--lows`, `--mediums`, and `--highs` for `Battery`
     to display an additional string depending on battery level.
+  - New options `-L` and `-H` for `Volume` to set low and high volume
+    levels, as well as `-l`, `-m`, and `-h` to display an additional
+    string depending on current volume level.
 
 
 ## Version 0.31 (October, 2019)

--- a/readme.md
+++ b/readme.md
@@ -1155,6 +1155,25 @@ more than one battery.
     - `--highd` _number_ High threshold for dB. Defaults to -5.0.
     - `--lowd` _number_ Low threshold for dB. Defaults to -30.0.
     - `--volume-icon-pattern` _string_ dynamic string for current volume in `volumeipat`.
+    - `-H` _number_ High threshold for volume (in %). Defaults to 60.0.
+        - Long option: `--highv`
+    - `-L` _number_ Low threshold for volume (in %). Defaults to 20.0.
+        - Long option: `--lowv`
+    - `-h`: _string_ High string
+        - The string added in front of `<status>` when the mixer element
+          is on and the volume percentage is higher than the `-H` threshold.
+          Defaults to "".
+        - Long option: `--highs`
+    - `-m`: _string_ Medium string
+        - The string added in front of `<status>` when the mixer element
+          is on and the volume percentage is lower than the `-H` threshold.
+          Defaults to "".
+        - Long option: `--mediums`
+    - `-l`: _string_ Low string
+        - The string added in front of `<status>` when the mixer element
+          is on and the volume percentage is lower than the `-L` threshold.
+          Defaults to "".
+        - Long option: `--lows`
 - Variables that can be used with the `-t`/`--template` argument:
             `volume`, `volumebar`, `volumevbar`, `volumeipat`, `dB`, `status`
 - Note that `dB` might only return 0 on your system. This is known

--- a/src/Xmobar/Plugins/Monitors/Volume.hs
+++ b/src/Xmobar/Plugins/Monitors/Volume.hs
@@ -65,6 +65,25 @@ defaultOpts = VolumeOpts
     , highString = ""
     }
 
+data VolumeStatus
+    = VolLow
+    | VolMedium
+    | VolHigh
+    | VolOff
+
+-- | Set the volume status according to user set thresholds and the current
+-- volume
+getVolStatus :: Float -- ^ Low volume threshold, in [0,100]
+             -> Float -- ^ High volume threshold, in  [0,100]
+             -> Float -- ^ Current volume, in [0,1]
+             -> VolumeStatus
+getVolStatus lo hi val'
+    | val >= hi = VolHigh
+    | val >= lo = VolMedium
+    | otherwise = VolLow
+  where
+    val = val' * 100
+
 options :: [OptDescr (VolumeOpts -> VolumeOpts)]
 options =
     [ Option "O" ["on"] (ReqArg (\x o -> o { onString = x }) "") ""
@@ -122,6 +141,14 @@ switchHelper opts cHelp strHelp = return $
 formatSwitch :: VolumeOpts -> Bool -> Monitor String
 formatSwitch opts True = switchHelper opts onColor onString
 formatSwitch opts False = switchHelper opts offColor offString
+-- | Convert the current volume status into user defined strings
+volHelper :: VolumeStatus -> VolumeOpts -> String
+volHelper volStatus opts =
+    case volStatus of
+        VolHigh -> highString opts
+        VolMedium -> mediumString opts
+        VolLow -> lowString opts
+        VolOff -> ""
 
 colorHelper :: Maybe String -> String
 colorHelper = maybe "" (\c -> "<fc=" ++ c ++ ">")

--- a/src/Xmobar/Plugins/Monitors/Volume.hs
+++ b/src/Xmobar/Plugins/Monitors/Volume.hs
@@ -42,6 +42,8 @@ data VolumeOpts = VolumeOpts
     , highDbThresh :: Float
     , lowDbThresh :: Float
     , volumeIconPattern :: Maybe IconPattern
+    , lowVolThresh :: Maybe Float
+    , highVolThresh :: Maybe Float
     }
 
 defaultOpts :: VolumeOpts
@@ -53,6 +55,8 @@ defaultOpts = VolumeOpts
     , highDbThresh = -5.0
     , lowDbThresh = -30.0
     , volumeIconPattern = Nothing
+    , lowVolThresh = Just 20
+    , highVolThresh = Just 60
     }
 
 options :: [OptDescr (VolumeOpts -> VolumeOpts)]
@@ -65,6 +69,8 @@ options =
     , Option "c" ["offc"] (ReqArg (\x o -> o { offColor = Just x }) "") ""
     , Option "" ["volume-icon-pattern"] (ReqArg (\x o ->
        o { volumeIconPattern = Just $ parseIconPattern x }) "") ""
+    , Option "L" ["lowv"] (ReqArg (\x o -> o { lowVolThresh = Just $ read x }) "") ""
+    , Option "H" ["highv"] (ReqArg (\x o -> o { highVolThresh = Just $ read x }) "") ""
     ]
 
 parseOpts :: [String] -> IO VolumeOpts

--- a/src/Xmobar/Plugins/Monitors/Volume.hs
+++ b/src/Xmobar/Plugins/Monitors/Volume.hs
@@ -44,6 +44,9 @@ data VolumeOpts = VolumeOpts
     , volumeIconPattern :: Maybe IconPattern
     , lowVolThresh :: Maybe Float
     , highVolThresh :: Maybe Float
+    , lowString :: String
+    , mediumString :: String
+    , highString :: String
     }
 
 defaultOpts :: VolumeOpts
@@ -55,8 +58,11 @@ defaultOpts = VolumeOpts
     , highDbThresh = -5.0
     , lowDbThresh = -30.0
     , volumeIconPattern = Nothing
-    , lowVolThresh = Just 20
-    , highVolThresh = Just 60
+    , lowVolThresh = Just 20.0
+    , highVolThresh = Just 60.0
+    , lowString = ""
+    , mediumString = ""
+    , highString = ""
     }
 
 options :: [OptDescr (VolumeOpts -> VolumeOpts)]
@@ -71,6 +77,9 @@ options =
        o { volumeIconPattern = Just $ parseIconPattern x }) "") ""
     , Option "L" ["lowv"] (ReqArg (\x o -> o { lowVolThresh = Just $ read x }) "") ""
     , Option "H" ["highv"] (ReqArg (\x o -> o { highVolThresh = Just $ read x }) "") ""
+    , Option "l" ["lows"] (ReqArg (\x o -> o { lowString = x }) "") ""
+    , Option "m" ["mediums"] (ReqArg (\x o -> o { mediumString = x }) "") ""
+    , Option "h" ["highs"] (ReqArg (\x o -> o { highString = x }) "") ""
     ]
 
 parseOpts :: [String] -> IO VolumeOpts


### PR DESCRIPTION
This basically implements the functionality from #403 for the `Volume` plugin. It adds five new arguments: `-L (--lowv)`, `-H (--highv)`, `-l (--lows)`, `-m (--mediums)`, and `-h (--highs)`. 
`-L` and `-H` are used to set percentage-based thresholds for the volume level. These two values default to `Just 20.0` and `Just 60.0` respectively. 
`-l`, `-m`, and `-h` can then be used to display an additional string, depending on the current volume level. This will only be displayed in front of the string defined by `-O`. All three values default to "", so as to not interfere with any configuration not explicitly setting them.

As for the commits:
  1. Adds the types for `-L` and `-H` to `VolumeOpts`, sets some defaults and adds `Option`s
  2. Does the same as 1. for `-l`, `-m`, and `-h`
  3. Adds the `VolumeStatus` type for convenient pattern matching and ways to convert between a volume percentage and a `VolumeStatus`, as well as a `VolumeStatus` and a string as defined by `-l`, `-m`, or `-h`.
  4. Changes the volume formatting so as to print the above defined strings in front of the `onString`.
  5. Updates the readme.
  6. Updates the changelog.

Usage example:
```
Config { font = "xft:FontAwesome:antialias=true:hinting=true:size=9,sans"
       , commands =  [Run Volume "default" "Master"
                       [ "--template", "<status> <volume>%"
                       , "--"
                       , "--on"     , ""
                       , "--lows"   , ""
                       , "--mediums", ""
                       , "--highs"  , ""
                       ] 10
       ]
       , template = "%default:Master%"
       }
```