### PR TITLE
add filtering option for Net devices

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -807,6 +807,7 @@ specification, such as `("clear", "<icon=weather-clear.xbm/>")`.
   in Kbytes per second, and you can set the `-S` to "True" to make them
   displayed with units (the string "Kb/s").
 - Default template: `<dev>: <rx>KB|<tx>KB`
+- Example of usage of `--devices` option: `["--", "--devices", "wlp2s0,enp0s20f41"]`
 
 ### `Wireless Interface Args RefreshRate`
 

--- a/readme.md
+++ b/readme.md
@@ -799,7 +799,8 @@ specification, such as `("clear", "<icon=weather-clear.xbm/>")`.
 - Thresholds are expressed in Kb/s
 - Args: default monitor arguments, plus:
   - `--rx-icon-pattern`: dynamic string for reception rate in `rxipat`.
-  - `--tx-icon-pattern`: dynamic string for transmission rate in `txipat`.
+  - `--tx-icon-pattern`: dynamic string for transmission rate in `txipat`
+  - `--devices`: comma-separated list of devices to show.
 - Variables that can be used with the `-t`/`--template` argument:
   `dev`, `rx`, `tx`, `rxbar`, `rxvbar`, `rxipat`, `txbar`, `txvbar`,
   `txipat`. Reception and transmission rates (`rx` and `tx`) are displayed

--- a/src/Xmobar/Plugins/Monitors/Common/Output.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Output.hs
@@ -17,8 +17,6 @@
 
 module Xmobar.Plugins.Monitors.Common.Output ( IconPattern
                                              , parseIconPattern
-                                             , DevList
-                                             , parseDevList
                                              , padString
                                              , showWithPadding
                                              , showWithColors
@@ -49,7 +47,6 @@ import Control.Monad (zipWithM)
 import Xmobar.Plugins.Monitors.Common.Types
 
 type IconPattern = Int -> String
-type DevList = [String]
 
 parseIconPattern :: String -> IconPattern
 parseIconPattern path =
@@ -60,14 +57,6 @@ parseIconPattern path =
         splitOnPercent (x:xs) =
             let rest = splitOnPercent xs
             in (x : head rest) : tail rest
-
-parseDevList :: String -> DevList
-parseDevList = splitOnComma
-  where splitOnComma [] = [[]]
-        splitOnComma (',':xs) = [] : splitOnComma xs
-        splitOnComma (x:xs) =
-           let rest = splitOnComma xs
-           in (x : head rest) : tail rest
 
 type Pos = (Int, Int)
 

--- a/src/Xmobar/Plugins/Monitors/Common/Output.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Output.hs
@@ -17,6 +17,8 @@
 
 module Xmobar.Plugins.Monitors.Common.Output ( IconPattern
                                              , parseIconPattern
+                                             , DevList
+                                             , parseDevList
                                              , padString
                                              , showWithPadding
                                              , showWithColors
@@ -47,6 +49,7 @@ import Control.Monad (zipWithM)
 import Xmobar.Plugins.Monitors.Common.Types
 
 type IconPattern = Int -> String
+type DevList = [String]
 
 parseIconPattern :: String -> IconPattern
 parseIconPattern path =
@@ -57,6 +60,14 @@ parseIconPattern path =
         splitOnPercent (x:xs) =
             let rest = splitOnPercent xs
             in (x : head rest) : tail rest
+
+parseDevList :: String -> DevList
+parseDevList = splitOnComma
+  where splitOnComma [] = [[]]
+        splitOnComma (',':xs) = [] : splitOnComma xs
+        splitOnComma (x:xs) =
+           let rest = splitOnComma xs
+           in (x : head rest) : tail rest
 
 type Pos = (Int, Int)
 

--- a/src/Xmobar/Plugins/Monitors/Net.hs
+++ b/src/Xmobar/Plugins/Monitors/Net.hs
@@ -34,12 +34,14 @@ import qualified Data.ByteString.Lazy.Char8 as B
 data NetOpts = NetOpts
   { rxIconPattern :: Maybe IconPattern
   , txIconPattern :: Maybe IconPattern
+  , onlyDevList :: Maybe DevList
   }
 
 defaultOpts :: NetOpts
 defaultOpts = NetOpts
   { rxIconPattern = Nothing
   , txIconPattern = Nothing
+  , onlyDevList = Nothing
   }
 
 options :: [OptDescr (NetOpts -> NetOpts)]
@@ -48,6 +50,8 @@ options =
      o { rxIconPattern = Just $ parseIconPattern x }) "") ""
   , Option "" ["tx-icon-pattern"] (ReqArg (\x o ->
      o { txIconPattern = Just $ parseIconPattern x }) "") ""
+  , Option "" ["only-dev-list"] (ReqArg (\x o ->
+     o { onlyDevList = Just $ parseDevList x }) "") ""
   ]
 
 parseOpts :: [String] -> IO NetOpts
@@ -187,10 +191,16 @@ parseNets = mapM $ uncurry parseNet
 
 runNets :: [(NetDevRef, String)] -> [String] -> Monitor String
 runNets refs argv = do
-  dev <- io $ parseActive refs
   opts <- io $ parseOpts argv
+  dev <- io $ parseActive $ filterRefs opts refs
   printNet opts dev
     where parseActive refs' = fmap selectActive (parseNets refs')
+          refInDevList opts' (_, refname') = case onlyDevList opts' of
+            Just theList -> refname' `elem` theList
+            Nothing -> True
+          filterRefs opts' refs' = case filter (refInDevList opts') refs' of
+            [] -> refs'
+            xs -> xs
           selectActive = maximum
 
 startNet :: String -> [String] -> Int -> (String -> IO ()) -> IO ()

--- a/src/Xmobar/Plugins/Monitors/Net.hs
+++ b/src/Xmobar/Plugins/Monitors/Net.hs
@@ -31,6 +31,16 @@ import System.IO.Error (catchIOError)
 
 import qualified Data.ByteString.Lazy.Char8 as B
 
+type DevList = [String]
+
+parseDevList :: String -> DevList
+parseDevList = splitOnComma
+  where splitOnComma [] = [[]]
+        splitOnComma (',':xs) = [] : splitOnComma xs
+        splitOnComma (x:xs) =
+           let rest = splitOnComma xs
+           in (x : head rest) : tail rest
+
 data NetOpts = NetOpts
   { rxIconPattern :: Maybe IconPattern
   , txIconPattern :: Maybe IconPattern
@@ -50,7 +60,7 @@ options =
      o { rxIconPattern = Just $ parseIconPattern x }) "") ""
   , Option "" ["tx-icon-pattern"] (ReqArg (\x o ->
      o { txIconPattern = Just $ parseIconPattern x }) "") ""
-  , Option "" ["only-dev-list"] (ReqArg (\x o ->
+  , Option "" ["devices"] (ReqArg (\x o ->
      o { onlyDevList = Just $ parseDevList x }) "") ""
   ]
 


### PR DESCRIPTION
Add option to specify which network devices to show. The option is relevant for instance when docker network interfaces are not of interest:

```
× sit0@NONE
√ wlp3s42
√ enp0s20f41
× br-uh14b3h3v
× docker0
× ethekjbrh14@if7
```
Example:
```
DynNetwork ["--", "--devices", "wlp3s42,enp0s20f41"] 10
```