### PR TITLE
Implement timer coalescing (noticeably less CPU/power usage)

### DIFF
--- a/src/Xmobar/App/EventLoop.hs
+++ b/src/Xmobar/App/EventLoop.hs
@@ -47,7 +47,10 @@ import Xmobar.X11.Text
 import Xmobar.X11.Draw
 import Xmobar.X11.Bitmap as Bitmap
 import Xmobar.X11.Types
+
+#ifndef THREADED_RUNTIME
 import Xmobar.X11.Events(nextEvent')
+#endif
 
 #ifdef XFT
 import Graphics.X11.Xft

--- a/src/Xmobar/App/Main.hs
+++ b/src/Xmobar/App/Main.hs
@@ -40,9 +40,10 @@ import Xmobar.X11.Types
 import Xmobar.X11.Text
 import Xmobar.X11.Window
 import Xmobar.App.Opts (recompileFlag, verboseFlag, getOpts, doOpts)
-import Xmobar.App.EventLoop (startLoop, startCommand)
+import Xmobar.App.EventLoop (startLoop, startCommand, newRefreshLock, refreshLock)
 import Xmobar.App.Compile (recompile, trace)
 import Xmobar.App.Config
+import Xmobar.App.Timer (withTimer)
 
 xmobar :: Config -> IO ()
 xmobar conf = withDeferSignals $ do
@@ -53,14 +54,16 @@ xmobar conf = withDeferSignals $ do
   cls   <- mapM (parseTemplate (commands conf) (sepChar conf))
                 (splitTemplate (alignSep conf) (template conf))
   sig   <- setupSignalHandler
-  bracket (mapM (mapM $ startCommand sig) cls)
-          cleanupThreads
-          $ \vars -> do
-    (r,w) <- createWin d fs conf
-    let ic = Map.empty
-        to = textOffset conf
-        ts = textOffsets conf ++ replicate (length fl) (-1)
-    startLoop (XConf d r w (fs:fl) (to:ts) ic conf) sig vars
+  refLock <- newRefreshLock
+  withTimer (refreshLock refLock) $
+    bracket (mapM (mapM $ startCommand sig) cls)
+            cleanupThreads
+            $ \vars -> do
+      (r,w) <- createWin d fs conf
+      let ic = Map.empty
+          to = textOffset conf
+          ts = textOffsets conf ++ replicate (length fl) (-1)
+      startLoop (XConf d r w (fs:fl) (to:ts) ic conf) sig refLock vars
 
 configFromArgs :: Config -> IO Config
 configFromArgs cfg = getArgs >>= getOpts >>= doOpts cfg . fst

--- a/src/Xmobar/App/Timer.hs
+++ b/src/Xmobar/App/Timer.hs
@@ -1,0 +1,130 @@
+------------------------------------------------------------------------------
+-- |
+-- Module: Xmobar.App.Timer
+-- Copyright: (c) 2019 Tomáš Janoušek
+-- License: BSD3-style (see LICENSE)
+--
+-- Maintainer: Tomáš Janoušek <tomi@nomi.cz>
+-- Stability: unstable
+--
+-- Timer coalescing for recurring actions.
+--
+------------------------------------------------------------------------------
+
+module Xmobar.App.Timer (doEveryTenthSeconds, withTimer) where
+
+import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.STM
+import Control.Exception (bracket, bracket_)
+import Control.Monad (forever, forM, forM_, guard)
+import Data.IORef
+import Data.Int (Int64)
+import Data.Map (Map)
+import qualified Data.Map as M
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Unique
+import System.IO.Unsafe (unsafePerformIO)
+
+newtype Timer = Timer (TVar Periods)
+
+type Periods = Map Unique Period
+
+data Period = Period { rate :: Int64, next :: Int64, tick :: TMVar (TMVar ()) }
+
+{-# NOINLINE timer #-}
+timer :: IORef (Maybe Timer)
+timer = unsafePerformIO (newIORef Nothing)
+
+now :: IO Int64
+now = do
+    posix <- getPOSIXTime
+    return $ floor (10 * posix)
+
+newPeriod :: Int64 -> IO (Unique, Period)
+newPeriod r = do
+    u <- newUnique
+    t <- now
+    v <- atomically newEmptyTMVar
+    let t' = t - t `mod` r
+    return (u, Period { rate = r, next = t', tick = v })
+
+-- | Perform a given action every N tenths of a second.
+--
+-- The timer is aligned with other timers to minimize the number of wakeups
+-- and unnecessary redraws.
+doEveryTenthSeconds :: Int -> IO () -> IO ()
+doEveryTenthSeconds r action = do
+    Just t <- readIORef timer
+    doEveryTenthSeconds' t r action
+
+doEveryTenthSeconds' :: Timer -> Int -> IO () -> IO ()
+doEveryTenthSeconds' (Timer periodsVar) r action = do
+    (u, p) <- newPeriod (fromIntegral r)
+    bracket_ (push u p) (pop u) $ forever $
+        bracket (atomically $ takeTMVar $ tick p)
+                (\doneVar -> atomically $ putTMVar doneVar ())
+                (const action)
+    where
+        push u p = atomically $ modifyTVar periodsVar (M.insert u p)
+        pop u = atomically $ modifyTVar periodsVar (M.delete u)
+
+-- | Start the timer coordination thread.
+withTimer :: (IO () -> IO ()) -> IO a -> IO a
+withTimer pauseRefresh action = do
+    periodsVar <- atomically $ newTVar M.empty
+    withAsync (timerLoop pauseRefresh periodsVar) $ \_ ->
+        bracket_
+            (writeIORef timer (Just (Timer periodsVar)))
+            (writeIORef timer Nothing) -- TODO: kill all periods?
+            action
+
+timerLoop :: (IO () -> IO ()) -> TVar Periods -> IO ()
+timerLoop pauseRefresh periodsVar = forever $ do
+    t <- now
+    toFire <- atomically $ do
+        periods <- readTVar periodsVar
+        writeTVar periodsVar (advanceTimers t periods)
+        return (timersToFire t periods)
+    pauseRefresh $ do
+        -- Fire timers ...
+        doneVars <- atomically $ forM toFire $ \p -> do
+            doneVar <- newEmptyTMVar
+            putTMVar (tick p) doneVar
+            return doneVar
+        -- ... and wait for them to avoid unnecessary redraws.
+        atomically $ forM_ doneVars takeTMVar
+    delayUntilNextFire periodsVar
+
+advanceTimers :: Int64 -> Periods -> Periods
+advanceTimers t = M.map advance
+    where
+        advance p | next p <= t = p { next = t - t `mod` rate p + rate p }
+                  | otherwise = p
+
+timersToFire :: Int64 -> Periods -> [Period]
+timersToFire t periods = [ p | p <- M.elems periods, next p <= t ]
+
+nextFireTime :: Periods -> Maybe Int64
+nextFireTime periods
+    | M.null periods = Nothing
+    | otherwise = Just $ minimum [ next p | p <- M.elems periods ]
+
+delayUntilNextFire :: TVar Periods -> IO ()
+delayUntilNextFire periodsVar = do
+    tMaybeNext <- fmap nextFireTime $ readTVarIO periodsVar
+    tNow <- now
+    delayVar <- case tMaybeNext of
+        Just tNext -> do
+            -- Work around the Int max bound: threadDelay takes an Int, we can
+            -- only sleep for so long, which is okay, we'll just check timers
+            -- sooner and sleep again.
+            let maxDelay = (maxBound :: Int) `div` 100000
+                delay = (tNext - tNow) `min` fromIntegral maxDelay
+                delayUsec = fromIntegral delay * 100000
+            registerDelay delayUsec
+        Nothing -> atomically $ newTVar False
+    atomically $ do
+        delayOver <- readTVar delayVar
+        tMaybeNext' <- fmap nextFireTime $ readTVar periodsVar
+        -- Return also if a new period is added (it may fire sooner).
+        guard $ delayOver || tMaybeNext /= tMaybeNext'

--- a/src/Xmobar/App/Timer.hs
+++ b/src/Xmobar/App/Timer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 ------------------------------------------------------------------------------
 -- |
 -- Module: Xmobar.App.Timer
@@ -11,16 +12,23 @@
 --
 ------------------------------------------------------------------------------
 
-module Xmobar.App.Timer (doEveryTenthSeconds, withTimer) where
+module Xmobar.App.Timer
+    ( doEveryTenthSeconds
+    , tenthSeconds
+    , withTimer
+    ) where
 
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM
-import Control.Exception (bracket, bracket_)
-import Control.Monad (forever, forM, forM_, guard)
+import Control.Exception
+import Control.Monad (forever, forM, guard)
+import Data.Foldable (foldrM)
 import Data.IORef
 import Data.Int (Int64)
 import Data.Map (Map)
 import qualified Data.Map as M
+import Data.Maybe (isJust)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Unique
 import System.IO.Unsafe (unsafePerformIO)
@@ -29,7 +37,12 @@ newtype Timer = Timer (TVar Periods)
 
 type Periods = Map Unique Period
 
-data Period = Period { rate :: Int64, next :: Int64, tick :: TMVar (TMVar ()) }
+data Tick = Tick (TMVar ()) | TimeOut
+
+data Period = Period { rate :: Int64, next :: Int64, tick :: TMVar Tick }
+
+data TimeOutException = TimeOutException deriving Show
+instance Exception TimeOutException
 
 {-# NOINLINE timer #-}
 timer :: IORef (Maybe Timer)
@@ -50,23 +63,47 @@ newPeriod r = do
 
 -- | Perform a given action every N tenths of a second.
 --
--- The timer is aligned with other timers to minimize the number of wakeups
--- and unnecessary redraws.
+-- The timer is aligned (coalesced) with other timers to minimize the number
+-- of wakeups and unnecessary redraws. If the action takes too long (one
+-- second or when the next timer is due), coalescing is disabled for it and it
+-- falls back to periodic sleep.
 doEveryTenthSeconds :: Int -> IO () -> IO ()
 doEveryTenthSeconds r action = do
     Just t <- readIORef timer
-    doEveryTenthSeconds' t r action
+    doEveryTenthSecondsCoalesced t r action `catch` \TimeOutException ->
+        doEveryTenthSecondsSleeping r action
 
-doEveryTenthSeconds' :: Timer -> Int -> IO () -> IO ()
-doEveryTenthSeconds' (Timer periodsVar) r action = do
+-- | Perform a given action every N tenths of a second,
+-- coalesce with other timers using a given Timer instance.
+doEveryTenthSecondsCoalesced :: Timer -> Int -> IO () -> IO ()
+doEveryTenthSecondsCoalesced (Timer periodsVar) r action = do
     (u, p) <- newPeriod (fromIntegral r)
-    bracket_ (push u p) (pop u) $ forever $
-        bracket (atomically $ takeTMVar $ tick p)
-                (\doneVar -> atomically $ putTMVar doneVar ())
-                (const action)
+    bracket_ (push u p) (pop u) $ forever $ bracket (wait p) done $ const action
     where
         push u p = atomically $ modifyTVar periodsVar (M.insert u p)
         pop u = atomically $ modifyTVar periodsVar (M.delete u)
+
+        wait p = atomically (takeTMVar $ tick p) >>= \case
+            Tick doneVar -> return doneVar
+            TimeOut -> throwIO TimeOutException
+        done doneVar = atomically $ putTMVar doneVar ()
+
+-- | Perform a given action every N tenths of a second,
+-- making no attempt to synchronize with other timers.
+doEveryTenthSecondsSleeping :: Int -> IO () -> IO ()
+doEveryTenthSecondsSleeping r action = go
+    where go = action >> tenthSeconds r >> go
+
+-- | Sleep for a given amount of tenths of a second.
+--
+-- (Work around the Int max bound: since threadDelay takes an Int, it
+-- is not possible to set a thread delay grater than about 45 minutes.
+-- With a little recursion we solve the problem.)
+tenthSeconds :: Int -> IO ()
+tenthSeconds s | s >= x = do threadDelay (x * 100000)
+                             tenthSeconds (s - x)
+               | otherwise = threadDelay (s * 100000)
+               where x = (maxBound :: Int) `div` 100000
 
 -- | Start the timer coordination thread.
 withTimer :: (IO () -> IO ()) -> IO a -> IO a
@@ -80,19 +117,25 @@ withTimer pauseRefresh action = do
 
 timerLoop :: (IO () -> IO ()) -> TVar Periods -> IO ()
 timerLoop pauseRefresh periodsVar = forever $ do
-    t <- now
-    toFire <- atomically $ do
+    tNow <- now
+    (toFire, tMaybeNext) <- atomically $ do
         periods <- readTVar periodsVar
-        writeTVar periodsVar (advanceTimers t periods)
-        return (timersToFire t periods)
+        let toFire = timersToFire tNow periods
+        let periods' = advanceTimers tNow periods
+        let tMaybeNext = nextFireTime periods'
+        writeTVar periodsVar periods'
+        return (toFire, tMaybeNext)
     pauseRefresh $ do
-        -- Fire timers ...
-        doneVars <- atomically $ forM toFire $ \p -> do
-            doneVar <- newEmptyTMVar
-            putTMVar (tick p) doneVar
-            return doneVar
-        -- ... and wait for them to avoid unnecessary redraws.
-        atomically $ forM_ doneVars takeTMVar
+        -- To avoid multiple refreshes, pause refreshing for up to 1 second,
+        -- fire timers and wait for them to finish (update their text).
+        -- Those that need more time (e.g. weather monitors) will be dropped
+        -- from timer coalescing and will fall back to periodic sleep.
+        timeoutVar <- registerDelay $ case tMaybeNext of
+            Just tNext -> fromIntegral ((tNext - tNow) `max` 10) * 100000
+            Nothing -> 1000000
+        fired <- fireTimers toFire
+        timeouted <- waitForTimers timeoutVar fired
+        timeoutTimers timeouted periodsVar
     delayUntilNextFire periodsVar
 
 advanceTimers :: Int64 -> Periods -> Periods
@@ -101,13 +144,40 @@ advanceTimers t = M.map advance
         advance p | next p <= t = p { next = t - t `mod` rate p + rate p }
                   | otherwise = p
 
-timersToFire :: Int64 -> Periods -> [Period]
-timersToFire t periods = [ p | p <- M.elems periods, next p <= t ]
+timersToFire :: Int64 -> Periods -> [(Unique, Period)]
+timersToFire t periods = [ (u, p) | (u, p) <- M.toList periods, next p <= t ]
 
 nextFireTime :: Periods -> Maybe Int64
 nextFireTime periods
     | M.null periods = Nothing
     | otherwise = Just $ minimum [ next p | p <- M.elems periods ]
+
+fireTimers :: [(Unique, Period)] -> IO [(Unique, TMVar ())]
+fireTimers toFire = atomically $ forM toFire $ \(u, p) -> do
+    doneVar <- newEmptyTMVar
+    putTMVar (tick p) (Tick doneVar)
+    return (u, doneVar)
+
+waitForTimers :: TVar Bool -> [(Unique, TMVar ())] -> IO [Unique]
+waitForTimers timeoutVar fired = atomically $ do
+    timeoutOver <- readTVar timeoutVar
+    dones <- forM fired $ \(u, doneVar) -> do
+        done <- isJust <$> tryReadTMVar doneVar
+        return (u, done)
+    guard $ timeoutOver || all snd dones
+    return [u | (u, False) <- dones]
+
+-- | Handle slow timers (drop and signal them to stop coalescing).
+timeoutTimers :: [Unique] -> TVar Periods -> IO ()
+timeoutTimers timers periodsVar = atomically $ do
+    periods <- readTVar periodsVar
+    periods' <- foldrM timeoutTimer periods timers
+    writeTVar periodsVar periods'
+
+timeoutTimer :: Unique -> Periods -> STM Periods
+timeoutTimer u periods = do
+    putTMVar (tick (periods M.! u)) TimeOut
+    return $ u `M.delete` periods
 
 delayUntilNextFire :: TVar Periods -> IO ()
 delayUntilNextFire periodsVar = do

--- a/src/Xmobar/Plugins/DateZone.hs
+++ b/src/Xmobar/Plugins/DateZone.hs
@@ -72,7 +72,7 @@ instance Exec DateZone where
        else
         go (date f locale)
 
-      where go func = func >>= cb >> tenthSeconds r >> go func
+      where go func = doEveryTenthSeconds r $ func >>= cb
 
 {-# NOINLINE localeLock #-}
 -- ensures that only one plugin instance sets the locale

--- a/src/Xmobar/Run/Command.hs
+++ b/src/Xmobar/Run/Command.hs
@@ -41,7 +41,7 @@ instance Exec Command where
     start (Com p as al r) cb =
       start (ComX p as ("Could not execute command " ++ p) al r) cb
     start (ComX prog args msg _ r) cb = if r > 0 then go else exec
-        where go = exec >> tenthSeconds r >> go
+        where go = doEveryTenthSeconds r exec
               exec = do
                 (i,o,e,p) <- runInteractiveProcess prog args Nothing Nothing
                 exit <- waitForProcess p

--- a/src/Xmobar/Run/Exec.hs
+++ b/src/Xmobar/Run/Exec.hs
@@ -23,6 +23,7 @@ import Prelude
 import Data.Char
 import Control.Concurrent
 
+import Xmobar.App.Timer (doEveryTenthSeconds)
 import Xmobar.System.Signal
 
 -- | Work around to the Int max bound: since threadDelay takes an Int, it
@@ -33,10 +34,6 @@ tenthSeconds s | s >= x = do threadDelay (x * 100000)
                              tenthSeconds (s - x)
                | otherwise = threadDelay (s * 100000)
                where x = (maxBound :: Int) `div` 100000
-
-doEveryTenthSeconds :: Int -> IO () -> IO ()
-doEveryTenthSeconds r action = go
-    where go = action >> tenthSeconds r >> go
 
 class Show e => Exec e where
     alias   :: e -> String

--- a/src/Xmobar/Run/Exec.hs
+++ b/src/Xmobar/Run/Exec.hs
@@ -21,19 +21,9 @@ module Xmobar.Run.Exec (Exec (..), tenthSeconds, doEveryTenthSeconds) where
 
 import Prelude
 import Data.Char
-import Control.Concurrent
 
-import Xmobar.App.Timer (doEveryTenthSeconds)
+import Xmobar.App.Timer (doEveryTenthSeconds, tenthSeconds)
 import Xmobar.System.Signal
-
--- | Work around to the Int max bound: since threadDelay takes an Int, it
--- is not possible to set a thread delay grater than about 45 minutes.
--- With a little recursion we solve the problem.
-tenthSeconds :: Int -> IO ()
-tenthSeconds s | s >= x = do threadDelay (x * 100000)
-                             tenthSeconds (s - x)
-               | otherwise = threadDelay (s * 100000)
-               where x = (maxBound :: Int) `div` 100000
 
 class Show e => Exec e where
     alias   :: e -> String

--- a/src/Xmobar/X11/Draw.hs
+++ b/src/Xmobar/X11/Draw.hs
@@ -62,6 +62,8 @@ drawInWin wr@(Rectangle _ _ wid ht) ~[left,center,right] = do
                          (defaultDepthOfScreen (defaultScreenOfDisplay d))
 #if XFT
   when (alpha c /= 255) (liftIO $ drawBackground d p (bgColor c) (alpha c) wr)
+#else
+  _ <- return wr
 #endif
   withColors d [bgColor c, borderColor c] $ \[bgcolor, bdcolor] -> do
     gc <- liftIO $ createGC  d w

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -72,7 +72,7 @@ flag with_xpm
   default: False
 
 flag with_threaded
-  description: Use threaded runtime.
+  description: Use threaded runtime. Required for timer coalescing (less power usage).
   default: False
 
 flag with_rtsopts

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -105,6 +105,7 @@ library
                    Xmobar.App.Main,
                    Xmobar.App.Opts,
                    Xmobar.App.Compile,
+                   Xmobar.App.Timer,
                    Xmobar.System.Utils,
                    Xmobar.System.StatFS,
                    Xmobar.System.Environment,
@@ -320,6 +321,7 @@ test-suite XmobarTest
                  Xmobar.Plugins.Monitors.Common.Output
                  Xmobar.Plugins.Monitors.Common.Files
                  Xmobar.Run.Exec
+                 Xmobar.App.Timer
                  Xmobar.System.Signal
 
   if flag(with_alsa) || flag(all_extensions)


### PR DESCRIPTION
xmobar currently runs every monitor in its own thread. Monitors that do periodic updates simply sleep and loop. This unfortunately leads to these threads coming out of sync, and xmobar ends up waking up and redrawing for every periodic monitor. In my case, that is 7 times per second, which is enough for xmobar to be at the top of "top" with more than 1% CPU usage, and to have a noticeable impact on battery life.

This commit adds a central timer coordination thread which makes sure that periodic updates happen together and that we only redraw once they're all done.

Together with PR #409, I managed to lower the idle power draw of my laptop from 4W to 3W.