### PR TITLE
DateZone: get timezone series from TZDIR

### DIFF
--- a/src/Xmobar/Plugins/DateZone.hs
+++ b/src/Xmobar/Plugins/DateZone.hs
@@ -28,6 +28,9 @@ import Xmobar.Run.Exec
 import Control.Concurrent.STM
 
 import System.IO.Unsafe
+import System.Environment (lookupEnv)
+
+import Data.Maybe (fromMaybe)
 
 import Data.Time.Format
 import Data.Time.LocalTime
@@ -63,7 +66,8 @@ instance Exec DateZone where
       locale <- getTimeLocale
       atomically $ putTMVar localeLock lock
       if z /= "" then do
-        timeZone <- getTimeZoneSeriesFromOlsonFile ("/usr/share/zoneinfo/" ++ z)
+        tzdir <- lookupEnv "TZDIR"
+        timeZone <- getTimeZoneSeriesFromOlsonFile ((fromMaybe "/usr/share/zoneinfo" tzdir) ++ "/" ++ z)
         go (dateZone f locale timeZone)
        else
         go (date f locale)


### PR DESCRIPTION
The DateZone plugin calls `getTimeZoneSeriesFromOlsonFile` using the
hard-coded path /usr/share/zoneinfo. While that may work just fine on
most Linux distros, it does not work on NixOS since that directory is
always located somewhere under /nix/store.

Based on mild research, it seems the environment variable TZDIR is
commonly set to the absolute path to `zoneinfo` (but without a trailing
slash).

This change modifies the DateZone plugin to first try getting
the zoneinfo path from the TZDIR environment variable, falling back
to the hard-coded path /usr/share/zoneinfo