### PR TITLE
Add options to the Weather plugin

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@ _New features_
   - New template parameter `<weather>` for the `Weather` plugin, potentially
     displaying specific weather conditions that are occurring near the
     station (thanks to *slotThe*).
+  - New option `--weathers`, for `Weather` to display a default string in
+    case the `weather` field is not reported.
 
 ## Version 0.32 (December, 2019)
 

--- a/readme.md
+++ b/readme.md
@@ -735,7 +735,11 @@ something like:
 - Aliases to the Station ID: so `Weather "LIPB" []` can be used in
   template as `%LIPB%`
 - Thresholds refer to temperature in the selected units
-- Args: default monitor arguments
+- Args: default monitor arguments, plus:
+  - `--weathers` _string_ : display a default string when the `weather`
+    monitor is not reported.
+    - short option: `-w`
+    - Default: ""
 - Variables that can be used with the `-t`/`--template` argument:
 	    `station`, `stationState`, `year`, `month`, `day`, `hour`,
 	    `windCardinal`, `windAzimuth`, `windMph`, `windKnots`, `windMs`, `windKmh`

--- a/src/Xmobar/Plugins/Monitors.hs
+++ b/src/Xmobar/Plugins/Monitors.hs
@@ -164,8 +164,8 @@ instance Exec Monitors where
     start (TopProc a r) = startTop a r
     start (TopMem a r) = runM a topMemConfig runTopMem r
 #ifdef WEATHER
-    start (Weather s a r) = runMD (a ++ [s]) weatherConfig runWeather r weatherReady
-    start (WeatherX s c a r) = runMD (a ++ [s]) weatherConfig (runWeather' c) r weatherReady
+    start (Weather s a r) = runMD (s : a) weatherConfig runWeather r weatherReady
+    start (WeatherX s c a r) = runMD (s : a) weatherConfig (runWeather' c) r weatherReady
 #endif
     start (Thermal z a r) = runM (a ++ [z]) thermalConfig runThermal r
     start (ThermalZone z a r) =

--- a/src/Xmobar/Plugins/Monitors/Weather.hs
+++ b/src/Xmobar/Plugins/Monitors/Weather.hs
@@ -37,7 +37,7 @@ import System.Console.GetOpt
 -- | Options the user may specify.
 data WeatherOpts = WeatherOpts
   { weatherString :: String
-  } deriving Show
+  }
 
 -- | Default values for options.
 defaultOpts :: WeatherOpts


### PR DESCRIPTION
Add a `WeatherOpts` type (plus a first option) to the weather plugin.  

The original motivation was to build upon #414, this time perhaps handling the "fields doesn't exist" case a bit more gracefully.

The existence of yet another identical `parseOpts` function is not ideal, but this pr might not be the best place for cleaning this up (I plan on actually doing that in a separate pr).