### PR TITLE
Replace parseOpts with a generic function

### DIFF
--- a/src/Xmobar/Plugins/MBox.hs
+++ b/src/Xmobar/Plugins/MBox.hs
@@ -19,6 +19,7 @@ import Prelude
 import Xmobar.Run.Exec
 #ifdef INOTIFY
 
+import Xmobar.Plugins.Monitors.Common (parseOptsWith)
 import Xmobar.System.Utils (changeLoop, expandHome)
 
 import Control.Monad (when)
@@ -63,12 +64,6 @@ options =
   , Option "s" ["suffix"] (ReqArg (\x o -> o { oSuffix = x }) "") ""
   ]
 
-parseOptions :: [String] -> IO Options
-parseOptions args =
-  case getOpt Permute options args of
-    (o, _, []) -> return $ foldr id defaults o
-    (_, _, errs) -> ioError . userError $ concat errs
-
 #else
 import System.IO
 #endif
@@ -86,7 +81,7 @@ instance Exec MBox where
           " but the MBox plugin requires it"
 #else
   start (MBox boxes args _) cb = do
-    opts <- parseOptions args
+    opts <- parseOptsWith options defaults args
     let showAll = oAll opts
         prefix = oPrefix opts
         suffix = oSuffix opts

--- a/src/Xmobar/Plugins/Mail.hs
+++ b/src/Xmobar/Plugins/Mail.hs
@@ -18,6 +18,7 @@ module Xmobar.Plugins.Mail(Mail(..),MailX(..)) where
 import Xmobar.Run.Exec
 #ifdef INOTIFY
 
+import Xmobar.Plugins.Monitors.Common (parseOptsWith)
 import Xmobar.System.Utils (expandHome, changeLoop)
 
 import Control.Monad
@@ -64,13 +65,6 @@ options =
   , Option "s" ["suffix"] (ReqArg (\x o -> o { oSuffix = x }) "") ""
   ]
 
-parseOptions :: [String] -> IO MOptions
-parseOptions args =
-  case getOpt Permute options args of
-    (o, _, []) -> return $ foldr id defaults o
-    (_, _, errs) -> ioError . userError $ concat errs
-
-
 -- | A list of mail box names and paths to maildirs.
 data Mail = Mail [(String, FilePath)] String
     deriving (Read, Show)
@@ -92,7 +86,7 @@ instance Exec MailX where
 #else
     start (MailX ms args _) cb = do
         vs <- mapM (const $ newTVarIO S.empty) ms
-        opts <- parseOptions args
+        opts <- parseOptsWith options defaults args
         let prefix = oPrefix opts
             suffix = oSuffix opts
             dir = oDir opts

--- a/src/Xmobar/Plugins/Monitors/Batt.hs
+++ b/src/Xmobar/Plugins/Monitors/Batt.hs
@@ -103,12 +103,6 @@ options =
   , Option "" ["highs"] (ReqArg (\x o -> o { highString = x }) "") ""
   ]
 
-parseOpts :: [String] -> IO BattOpts
-parseOpts argv =
-  case getOpt Permute options argv of
-    (o, _, []) -> return $ foldr id defaultOpts o
-    (_, _, errs) -> ioError . userError $ concat errs
-
 data Status = Charging | Discharging | Full | Idle | Unknown deriving (Read, Eq)
 
 data Result = Result Float Float Float Status | NA
@@ -245,7 +239,7 @@ runBatt = runBatt' ["BAT", "BAT0", "BAT1", "BAT2"]
 
 runBatt' :: [String] -> [String] -> Monitor String
 runBatt' bfs args = do
-  opts <- io $ parseOpts args
+  opts <- io $ parseOptsWith options defaultOpts args
   let sp = incPerc opts
   c <- io $ readBatteries opts =<< mapM batteryFiles bfs
   suffix <- getConfigValue useSuffix

--- a/src/Xmobar/Plugins/Monitors/Bright.hs
+++ b/src/Xmobar/Plugins/Monitors/Bright.hs
@@ -44,13 +44,6 @@ options = [ Option "D" ["device"] (ReqArg (\x o -> o { subDir = x }) "") ""
              o { curBrightIconPattern = Just $ parseIconPattern x }) "") ""
           ]
 
--- from Batt.hs
-parseOpts :: [String] -> IO BrightOpts
-parseOpts argv =
-  case getOpt Permute options argv of
-    (o, _, []) -> return $ foldr id defaultOpts o
-    (_, _, errs) -> ioError . userError $ concat errs
-
 sysDir :: FilePath
 sysDir = "/sys/class/backlight/"
 
@@ -75,7 +68,7 @@ brightFiles opts = do
 
 runBright :: [String] ->  Monitor String
 runBright args = do
-  opts <- io $ parseOpts args
+  opts <- io $ parseOptsWith options defaultOpts args
   f <- io $ brightFiles opts
   c <- io $ readBright f
   case f of

--- a/src/Xmobar/Plugins/Monitors/Cpu.hs
+++ b/src/Xmobar/Plugins/Monitors/Cpu.hs
@@ -35,12 +35,6 @@ options =
      o { loadIconPattern = Just $ parseIconPattern x }) "") ""
   ]
 
-parseOpts :: [String] -> IO CpuOpts
-parseOpts argv =
-  case getOpt Permute options argv of
-    (o, _, []) -> return $ foldr id defaultOpts o
-    (_, _, errs) -> ioError . userError $ concat errs
-
 cpuConfig :: IO MConfig
 cpuConfig = mkMConfig
        "Cpu: <total>%"
@@ -77,7 +71,7 @@ formatCpu opts xs = do
 runCpu :: CpuDataRef -> [String] -> Monitor String
 runCpu cref argv =
     do c <- io (parseCpu cref)
-       opts <- io $ parseOpts argv
+       opts <- io $ parseOptsWith options defaultOpts argv
        l <- formatCpu opts c
        parseTemplate l
 

--- a/src/Xmobar/Plugins/Monitors/Mem.hs
+++ b/src/Xmobar/Plugins/Monitors/Mem.hs
@@ -41,12 +41,6 @@ options =
      o { availableIconPattern = Just $ parseIconPattern x }) "") ""
   ]
 
-parseOpts :: [String] -> IO MemOpts
-parseOpts argv =
-  case getOpt Permute options argv of
-    (o, _, []) -> return $ foldr id defaultOpts o
-    (_, _, errs) -> ioError . userError $ concat errs
-
 memConfig :: IO MConfig
 memConfig = mkMConfig
        "Mem: <usedratio>% (<cache>M)" -- template
@@ -91,6 +85,6 @@ formatMem _ _ = replicate 10 `fmap` getConfigValue naString
 runMem :: [String] -> Monitor String
 runMem argv =
     do m <- io parseMEM
-       opts <- io $ parseOpts argv
+       opts <- io $ parseOptsWith options defaultOpts argv
        l <- formatMem opts m
        parseTemplate l

--- a/src/Xmobar/Plugins/Monitors/MultiCoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/MultiCoreTemp.hs
@@ -60,12 +60,6 @@ options = [ Option [] ["max-icon-pattern"]
               ""
           ]
 
--- | Parse Arguments and apply them to Options.
-parseOpts :: [String] -> IO CTOpts
-parseOpts argv = case getOpt Permute options argv of
-                   (opts , _ , []  ) -> return $ foldr id defaultOpts opts
-                   (_    , _ , errs) -> ioError . userError $ concat errs
-
 -- | Generate Config with a default template and options.
 cTConfig :: IO MConfig
 cTConfig = mkMConfig cTTemplate cTOptions
@@ -157,7 +151,7 @@ formatCT opts cTs = do let CTOpts { mintemp = minT
 
 runCT :: [String] -> Monitor String
 runCT argv = do cTs <- io parseCT
-                opts <- io $ parseOpts argv
+                opts <- io $ parseOptsWith options defaultOpts argv
                 l <- formatCT opts cTs
                 parseTemplate l
 

--- a/src/Xmobar/Plugins/Monitors/MultiCpu.hs
+++ b/src/Xmobar/Plugins/Monitors/MultiCpu.hs
@@ -47,12 +47,6 @@ options =
   , Option "" ["contiguous-icons"] (NoArg (\o -> o {contiguous = True})) ""
   ]
 
-parseOpts :: [String] -> IO MultiCpuOpts
-parseOpts argv =
-  case getOpt Permute options argv of
-    (o, _, []) -> return $ foldr id defaultOpts o
-    (_, _, errs) -> ioError . userError $ concat errs
-
 variables :: [String]
 variables = ["bar", "vbar","ipat","total","user","nice","system","idle"]
 vNum :: Int
@@ -122,7 +116,7 @@ formatAutoCpus opts xs =
 runMultiCpu :: CpuDataRef -> [String] -> Monitor String
 runMultiCpu cref argv =
   do c <- io $ parseCpuData cref
-     opts <- io $ parseOpts argv
+     opts <- io $ parseOptsWith options defaultOpts argv
      l <- formatMultiCpus opts c
      a <- formatAutoCpus opts l
      parseTemplate $ a ++ l

--- a/src/Xmobar/Plugins/Monitors/Net.hs
+++ b/src/Xmobar/Plugins/Monitors/Net.hs
@@ -68,12 +68,6 @@ options =
      o { onlyDevList = Just $ parseDevList x }) "") ""
   ]
 
-parseOpts :: [String] -> IO NetOpts
-parseOpts argv =
-  case getOpt Permute options argv of
-    (o, _, []) -> return $ foldr id defaultOpts o
-    (_, _, errs) -> ioError . userError $ concat errs
-
 data UnitPerSec = Bs | KBs | MBs | GBs deriving (Eq,Enum,Ord)
 data NetValue = NetValue Float UnitPerSec deriving (Eq,Show)
 
@@ -188,7 +182,7 @@ parseNet nref nd = do
 runNet :: NetDevRef -> String -> [String] -> Monitor String
 runNet nref i argv = do
   dev <- io $ parseNet nref i
-  opts <- io $ parseOpts argv
+  opts <- io $ parseOptsWith options defaultOpts argv
   printNet opts dev
 
 parseNets :: [(NetDevRef, String)] -> IO [NetDevRate]
@@ -196,7 +190,7 @@ parseNets = mapM $ uncurry parseNet
 
 runNets :: [(NetDevRef, String)] -> [String] -> Monitor String
 runNets refs argv = do
-  opts <- io $ parseOpts argv
+  opts <- io $ parseOptsWith options defaultOpts argv
   dev <- io $ parseActive $ filterRefs opts refs
   printNet opts dev
     where parseActive refs' = fmap selectActive (parseNets refs')

--- a/src/Xmobar/Plugins/Monitors/Volume.hs
+++ b/src/Xmobar/Plugins/Monitors/Volume.hs
@@ -101,12 +101,6 @@ options =
     , Option "h" ["highs"] (ReqArg (\x o -> o { highString = x }) "") ""
     ]
 
-parseOpts :: [String] -> IO VolumeOpts
-parseOpts argv =
-    case getOpt Permute options argv of
-        (o, _, []) -> return $ foldr id defaultOpts o
-        (_, _, errs) -> ioError . userError $ concat errs
-
 percent :: Integer -> Integer -> Integer -> Float
 percent v' lo' hi' = (v - lo) / (hi - lo)
   where v = fromIntegral v'
@@ -173,7 +167,7 @@ formatDb opts dbi = do
 
 runVolume :: String -> String -> [String] -> Monitor String
 runVolume mixerName controlName argv = do
-    opts <- io $ parseOpts argv
+    opts <- io $ parseOptsWith options defaultOpts argv
     runVolumeWith opts mixerName controlName
 
 runVolumeWith :: VolumeOpts -> String -> String -> Monitor String

--- a/src/Xmobar/Plugins/Monitors/Weather.hs
+++ b/src/Xmobar/Plugins/Monitors/Weather.hs
@@ -26,12 +26,7 @@ import qualified Data.ByteString.Lazy.Char8 as B
 import Data.Char (toLower)
 
 import Text.ParserCombinators.Parsec
-import System.Console.GetOpt
-    ( ArgDescr(ReqArg)
-    , ArgOrder(Permute)
-    , OptDescr(Option)
-    , getOpt
-    )
+import System.Console.GetOpt (ArgDescr(ReqArg), OptDescr(Option))
 
 
 -- | Options the user may specify.
@@ -50,13 +45,6 @@ options :: [OptDescr (WeatherOpts -> WeatherOpts)]
 options =
   [ Option "w" ["weathers"] (ReqArg (\s o -> o { weatherString = s }) "") ""
   ]
-
--- | Try to parse arguments from the config file and apply them.
-parseOpts :: [String] -> IO WeatherOpts
-parseOpts argv =
-    case getOpt Permute options argv of
-        (o, _, []  ) -> return $ foldr id defaultOpts o
-        (_, _, errs) -> ioError . userError $ concat errs
 
 weatherConfig :: IO MConfig
 weatherConfig = mkMConfig
@@ -260,7 +248,7 @@ runWeather = runWeather' []
 runWeather' :: [(String, String)] -> [String] -> Monitor String
 runWeather' sks args =
     do d <- io $ getData $ head args
-       o <- io $ parseOpts args
+       o <- io $ parseOptsWith options defaultOpts args
        i <- io $ runP parseData d
        formatWeather o sks i
 

--- a/src/Xmobar/Plugins/Monitors/Wireless.hs
+++ b/src/Xmobar/Plugins/Monitors/Wireless.hs
@@ -34,12 +34,6 @@ options =
      opts { qualityIconPattern = Just $ parseIconPattern d }) "") ""
   ]
 
-parseOpts :: [String] -> IO WirelessOpts
-parseOpts argv =
-  case getOpt Permute options argv of
-       (o, _, []) -> return $ foldr id defaultOpts o
-       (_, _, errs) -> ioError . userError $ concat errs
-
 wirelessConfig :: IO MConfig
 wirelessConfig =
   mkMConfig "<essid> <quality>"
@@ -47,7 +41,7 @@ wirelessConfig =
 
 runWireless :: String -> [String] -> Monitor String
 runWireless iface args = do
-  opts <- io $ parseOpts args
+  opts <- io $ parseOptsWith options defaultOpts args
   iface' <- if "" == iface then io findInterface else return iface
   wi <- io $ getWirelessInfo iface'
   na <- getConfigValue naString


### PR DESCRIPTION
As promised in #416, this replaces the `parseOpts` function with a generic `parseOptsWith` one, in an effort to reduce code duplication.  