### PR TITLE
Add <volumestatus> template to Volume

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ _New features_
     station (thanks to *slotThe*).
   - New option `--weathers`, for `Weather` to display a default string in
     case the `weather` field is not reported (thanks to *slotThe*).
+  - New template parameter `<volumestatus>` for the `Volume` plugin, combining
+    the effects of `<volume>` and `<status>`.  This will show the volume
+    (possibly prefixed by `onString` or a percentage-based string) if and only
+    if the volume is not muted.  Otherwise it will show the `offString`.
 
 ## Version 0.32 (December, 2019)
 

--- a/readme.md
+++ b/readme.md
@@ -1182,7 +1182,8 @@ more than one battery.
           Defaults to "".
         - Long option: `--lows`
 - Variables that can be used with the `-t`/`--template` argument:
-            `volume`, `volumebar`, `volumevbar`, `volumeipat`, `dB`, `status`
+            `volume`, `volumebar`, `volumevbar`, `volumeipat`, `dB`, `status`,
+            `volumestatus`
 - Note that `dB` might only return 0 on your system. This is known
   to happen on systems with a pulseaudio backend.
 - Default template: `Vol: <volume>% <status>`


### PR DESCRIPTION
Okay, I hope it works this time...

Copying directly from #419:
    Closes #361 by adding the provided functionality.  No new options were
    created, as we already have quite usable `onString`, `offString`, as well as
    `[low,mid,high]String` variables.  All get prepended to the volume with
    this, as having `<status>` before `<volume>` seems most natural.