### PR TITLE
Remove redundant functions and use parseOptsWith instead

### DIFF
--- a/src/Xmobar/Plugins/Monitors/MPD.hs
+++ b/src/Xmobar/Plugins/Monitors/MPD.hs
@@ -64,7 +64,7 @@ withMPD opts = M.withMPD_ (mHost opts) (mPort opts)
 
 runMPD :: [String] -> Monitor String
 runMPD args = do
-  opts <- io $ mopts args
+  opts <- io $ parseOptsWith options defaultOpts args
   status <- io $ withMPD opts M.status
   song <- io $ withMPD opts M.currentSong
   s <- parseMPD status song opts
@@ -79,7 +79,7 @@ mpdWait = do
 
 mpdReady :: [String] -> Monitor Bool
 mpdReady args = do
-  opts <- io $ mopts args
+  opts <- io $ parseOptsWith options defaultOpts args
   response <- io $ withMPD opts M.ping
   case response of
     Right _         -> return True
@@ -88,12 +88,6 @@ mpdReady args = do
     Left M.NoMPD    -> return False
     Left (M.ConnectionError _) -> return False
     Left _          -> return True
-
-mopts :: [String] -> IO MOpts
-mopts argv =
-  case getOpt Permute options argv of
-    (o, _, []) -> return $ foldr id defaultOpts o
-    (_, _, errs) -> ioError . userError $ concat errs
 
 parseMPD :: M.Response M.Status -> M.Response (Maybe M.Song) -> MOpts
             -> Monitor [String]


### PR DESCRIPTION
As the title suggests, it seems like my regexes in #418 weren't strong enough
and so some functions slipped through the cracks, sorry about that.  This commit
should catch all of the ones I missed last time.