### PR TITLE
Use a single Manager across the whole application

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,9 @@ _New features_
     `offString` (thanks to *slotThe*).
   - `Battery` and `BatteryN` now support FreeBSD (thanks to Dhananjay
     Balan).
+  - New option `--useManager` for `Weather` and `UVMeter` to decide whether to
+    use one single manager per monitor for managing network connections or
+    create a new one every time a connection is made.
 
 ## Version 0.32 (December, 2019)
 

--- a/readme.md
+++ b/readme.md
@@ -740,6 +740,11 @@ something like:
     variable is not reported.
     - short option: `-w`
     - Default: ""
+  - `--useManager` _bool_ : Whether to use one single manager per monitor for
+    managing network connections or create a new one every time a connection is
+    made.
+    - Short option: `-m`
+    - Default: True
 - Variables that can be used with the `-t`/`--template` argument:
 	    `station`, `stationState`, `year`, `month`, `day`, `hour`,
 	    `windCardinal`, `windAzimuth`, `windMph`, `windKnots`, `windMs`, `windKmh`
@@ -1414,9 +1419,14 @@ following differences:
 
 ### `UVMeter`
 
-- Aliases to "uv " + station id. For example: `%uv brisbane%` or `%uv
-  alice springs%`
-- Args: default monitor arguments.
+- Aliases to "uv " + station id. For example: `%uv Brisbane%` or `%uv
+  Alice Springs%`
+- Args: default monitor arguments, plus:
+  - `--useManager` _bool_ : Whether to use one single manager per monitor for
+    managing network connections or create a new one every time a connection is
+    made.
+    - Short option: `-m`
+    - Default: True
 
 - *Reminder:* Keep the refresh rate high, to avoid making unnecessary
   requests every time the plug-in is run.
@@ -1424,7 +1434,7 @@ following differences:
   http://www.arpansa.gov.au/uvindex/realtime/xml/uvvalues.xml
 - Example:
 
-        Run UVMeter "brisbane" ["-H", "3", "-L", "3", "--low", "green", "--high", "red"] 900
+        Run UVMeter "Brisbane" ["-H", "3", "-L", "3", "--low", "green", "--high", "red"] 900
 
 ## Executing External Commands
 

--- a/src/Xmobar/Plugins/Monitors.hs
+++ b/src/Xmobar/Plugins/Monitors.hs
@@ -164,8 +164,8 @@ instance Exec Monitors where
     start (TopProc a r) = startTop a r
     start (TopMem a r) = runM a topMemConfig runTopMem r
 #ifdef WEATHER
-    start (Weather s a r) = runMD (s : a) weatherConfig runWeather r weatherReady
-    start (WeatherX s c a r) = runMD (s : a) weatherConfig (runWeather' c) r weatherReady
+    start (Weather  s   a r) = startWeather    s a r
+    start (WeatherX s c a r) = startWeather' c s a r
 #endif
     start (Thermal z a r) = runM (a ++ [z]) thermalConfig runThermal r
     start (ThermalZone z a r) =

--- a/src/Xmobar/Plugins/Monitors.hs
+++ b/src/Xmobar/Plugins/Monitors.hs
@@ -19,7 +19,7 @@ module Xmobar.Plugins.Monitors where
 
 import Xmobar.Run.Exec
 
-import Xmobar.Plugins.Monitors.Common (runM, runMD)
+import Xmobar.Plugins.Monitors.Common (runM)
 #ifdef WEATHER
 import Xmobar.Plugins.Monitors.Weather
 #endif
@@ -47,7 +47,7 @@ import Xmobar.Plugins.Monitors.Wireless
 #endif
 #ifdef LIBMPD
 import Xmobar.Plugins.Monitors.MPD
-import Xmobar.Plugins.Monitors.Common (runMBD)
+import Xmobar.Plugins.Monitors.Common (runMBD, runMD)
 #endif
 #ifdef ALSA
 import Xmobar.Plugins.Monitors.Volume
@@ -184,7 +184,7 @@ instance Exec Monitors where
     start (Uptime a r) = runM a uptimeConfig runUptime r
     start (CatInt _ s a r) = runM a catIntConfig (runCatInt s) r
 #ifdef UVMETER
-    start (UVMeter s a r) = runM (a ++ [s]) uvConfig runUVMeter r
+    start (UVMeter s a r) = startUVMeter s a r
 #endif
 #ifdef IWLIB
     start (Wireless i a r) = runM a wirelessConfig (runWireless i) r

--- a/src/Xmobar/Plugins/Monitors/Common/Run.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Run.hs
@@ -19,6 +19,7 @@ module Xmobar.Plugins.Monitors.Common.Run ( runM
                                           , runMD
                                           , runMB
                                           , runMBD
+                                          , getArgvs
                                           ) where
 
 import Control.Exception (SomeException,handle)
@@ -54,6 +55,13 @@ options =
     , Option "T" ["maxtwidth"] (ReqArg MaxTotalWidth "Maximum total width") "Maximum total width"
     , Option "E" ["maxtwidthellipsis"] (ReqArg MaxTotalWidthEllipsis "Maximum total width ellipsis") "Ellipsis to be added to the total text when it has reached its max width."
     ]
+
+-- | Get all argument values out of a list of arguments.
+getArgvs :: [String] -> [String]
+getArgvs args =
+    case getOpt Permute options args of
+        (_, n, []  ) -> n
+        (_, _, errs) -> errs
 
 doArgs :: [String]
        -> ([String] -> Monitor String)

--- a/src/Xmobar/Plugins/Monitors/Common/Types.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Types.hs
@@ -25,8 +25,9 @@ module Xmobar.Plugins.Monitors.Common.Types ( Monitor
                                             , io
                                             ) where
 
-import Data.IORef
-import Control.Monad.Reader
+import Control.Monad.Reader (ReaderT, ask, liftIO)
+import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
+
 
 type Monitor a = ReaderT MConfig IO a
 

--- a/src/Xmobar/Plugins/Monitors/CoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/CoreTemp.hs
@@ -25,8 +25,7 @@ import Data.Char (isDigit)
 coreTempConfig :: IO MConfig
 coreTempConfig = mkMConfig
        "Temp: <core0>C" -- template
-       (map ((++) "core" . show) [0 :: Int ..]) -- available
-                                                -- replacements
+       (map ((++) "core" . show) [0 :: Int ..]) -- available replacements
 
 -- |
 -- Function retrieves monitor string holding the core temperature

--- a/src/Xmobar/Plugins/Monitors/UVMeter.hs
+++ b/src/Xmobar/Plugins/Monitors/UVMeter.hs
@@ -22,6 +22,7 @@ import Network.HTTP.Conduit
        (parseRequest, newManager, tlsManagerSettings, httpLbs,
         responseBody)
 import Data.ByteString.Lazy.Char8 as B
+import Data.IORef (newIORef, readIORef)
 import Text.Read (readMaybe)
 import Text.Parsec
 import Text.Parsec.String

--- a/src/Xmobar/Plugins/Monitors/Weather.hs
+++ b/src/Xmobar/Plugins/Monitors/Weather.hs
@@ -25,8 +25,6 @@ import Data.Maybe (fromMaybe)
 import Network.HTTP.Conduit
 import Network.HTTP.Types.Status
 import Network.HTTP.Types.Method
-import qualified Data.ByteString.Lazy.Char8 as B
-import Data.Char (toLower)
 
 import Text.ParserCombinators.Parsec
 import System.Console.GetOpt (ArgDescr(ReqArg), OptDescr(Option))

--- a/src/Xmobar/Plugins/Monitors/Weather.hs
+++ b/src/Xmobar/Plugins/Monitors/Weather.hs
@@ -19,6 +19,10 @@ import Xmobar.Plugins.Monitors.Common
 
 import qualified Control.Exception as CE
 
+import Control.Monad.Reader (asks)
+import qualified Data.ByteString.Lazy.Char8 as B
+import Data.Char (toLower)
+import Data.IORef (newIORef, readIORef)
 import Network.HTTP.Conduit
 import Network.HTTP.Types.Status
 import Network.HTTP.Types.Method


### PR DESCRIPTION
As per http-conduit's
[documentation](https://hackage.haskell.org/package/http-conduit-2.3.7.3/docs/Network-HTTP-Conduit.html):
"Creating a new Manager is a relatively expensive operation, you are advised to
share a single Manager between requests instead."

So far, every monitor that needed to connect to the internet (`Weather` and
`UVMeter`) created a new manager every time a connection was made.  This commit
introduces being able to set a manager via a record field in the `Monitor` type, so
that it can be retrieved by applications at will.

A caveat of this is that we now have a dependency on `http-conduit`, even if
neither of the plugins are loaded.  I would imagine this could be solved via an
`ifdef`, but I did not want to use the preprocessor any more than absolutely
necessary.  It's your call of course.