### PR TITLE
Battery: fix time calculations on some Linux systems

### DIFF
--- a/src/Xmobar/Plugins/Monitors/Batt.hs
+++ b/src/Xmobar/Plugins/Monitors/Batt.hs
@@ -227,7 +227,7 @@ readBattery sc files =
            a' = max a b -- sometimes the reported max charge is lower than
        return $ Battery (3600 * a' / sc') -- wattseconds
                         (3600 * b / sc') -- wattseconds
-                        (d / sc') -- watts
+                        (abs d / sc') -- watts
                         s -- string: Discharging/Charging/Full
     where grab f = handle onError $ withFile f ReadMode (fmap read . hGetLine)
           onError = const (return (-1)) :: SomeException -> IO Float


### PR DESCRIPTION
The calculations are based on the assumption that current_now (or
power_now) are always positive. However, power_supply documentation in
the kernel sources say nothing about it, and so some drivers provide a
signed value (e.g. bq27xxx_battery_current).

Discovered and fixed on ac100/paz00 netbook.