### PR TITLE
Wireless: fix hlint warnings, reenable CI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ install:
   - wget https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh
 
 script:
-#  - sh ./travis.sh src
+  - sh ./travis.sh src
   - cabal configure --enable-tests -fall_extensions && cabal build && cabal test


### PR DESCRIPTION
This makes the code hlint-clean for --cpp-define=USE_NL80211,
--cpp-define=IWLIB and without --cpp-define too.

Probably it makes sense to run hlint after cabal build so that it can honour cabal_macros.h