### PR TITLE
Add trailing linefeed to --version output.

### DIFF
--- a/src/Xmobar/App/Opts.hs
+++ b/src/Xmobar/App/Opts.hs
@@ -106,7 +106,7 @@ info :: String
 info = "xmobar " ++ showVersion version
         ++ "\n (C) 2010 - 2020 Jose A Ortega Ruiz"
         ++ "\n (C) 2007 - 2010 Andrea Rossato\n "
-        ++ mail ++ "\n" ++ license
+        ++ mail ++ "\n" ++ license ++ "\n"
 
 mail :: String
 mail = "<mail@jao.io>"


### PR DESCRIPTION
Previously `xmobar --version` would leave its last line of output awkwardly unterminated.