### PR TITLE
Require bytestring >= 0.10.8.2.

### DIFF
--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -169,7 +169,7 @@ library
       regex-compat,
       process,
       old-locale,
-      bytestring,
+      bytestring >= 0.10.8.2,
       directory,
       unix,
       time,


### PR DESCRIPTION
Version 0.10.8.1 contains a bug in the readFile function that misbehaves
on things like magic procfs files where stat(2) returns an st_size of
zero, which breaks the Net monitor and such; 0.10.8.2 contains the fix.

(See #434.)