### PR TITLE
Avoid busy looping by not catching all exceptions

### DIFF
--- a/src/Xmobar/Plugins/StdinReader.hs
+++ b/src/Xmobar/Plugins/StdinReader.hs
@@ -31,7 +31,7 @@ data StdinReader = StdinReader | UnsafeStdinReader
 
 instance Exec StdinReader where
   start stdinReader cb = do
-    s <- handle (\(SomeException e) -> do hPrint stderr e; return "") getLine
+    s <- getLine
     cb $ escape stdinReader s
     eof <- isEOF
     if eof

--- a/src/Xmobar/Run/Exec.hs
+++ b/src/Xmobar/Run/Exec.hs
@@ -10,7 +10,7 @@
 --
 -- The 'Exec' class and the 'Command' data type.
 --
--- The 'Exec' class rappresents the executable types, whose constructors may
+-- The 'Exec' class represents the executable types, whose constructors may
 -- appear in the 'Config.commands' field of the 'Config.Config' data type.
 --
 -- The 'Command' data type is for OS commands to be run by xmobar

--- a/src/Xmobar/System/Utils.hs
+++ b/src/Xmobar/System/Utils.hs
@@ -17,7 +17,7 @@
 ------------------------------------------------------------------------------
 
 
-module Xmobar.System.Utils (expandHome, changeLoop)
+module Xmobar.System.Utils (expandHome, changeLoop, onSomeException)
 where
 
 import Control.Monad
@@ -25,6 +25,7 @@ import Control.Concurrent.STM
 
 import System.Environment
 import System.FilePath
+import Control.Exception
 
 expandHome :: FilePath -> IO FilePath
 expandHome ('~':'/':path) = fmap (</> path) (getEnv "HOME")
@@ -39,3 +40,13 @@ changeLoop s f = atomically s >>= go
             new <- s
             guard (new /= old)
             return new)
+
+-- | Like 'finally', but only performs the final action if there was an
+-- exception raised by the computation.
+--
+-- Note that this implementation is a slight modification of
+-- onException function.
+onSomeException :: IO a -> (SomeException -> IO b) -> IO a
+onSomeException io what = io `catch` \e -> do _ <- what e
+                                              throwIO (e :: SomeException)
+


### PR DESCRIPTION
This specifically avoids situation described in this issue https://github.com/jaor/xmobar/issues/438 where the handle was throwing the IOException continously in a loop:

```
<stdin>: hGetLine: invalid argument (invalid byte sequence)
```

It happened because my system's environment wasn't right, but the proper behaviour here would be to let it to throw the exception rather than leading to a busy loop.

I did some git blame to find out that this commit introduced the behaviour: https://github.com/jaor/xmobar/commit/fc24dc1874dcf7c9e66e21502a58b40cbe627c85 but there was no reason mentioned in the commit for trying to capture all exceptions.