### PR TITLE
Fix crashes/busy looping happening via fn plugin

### DIFF
--- a/src/Xmobar/App/EventLoop.hs
+++ b/src/Xmobar/App/EventLoop.hs
@@ -40,6 +40,7 @@ import Control.Exception (bracket_, handle, SomeException(..))
 import Data.Bits
 import Data.Map hiding (foldr, map, filter)
 import Data.Maybe (fromJust, isJust)
+import qualified Data.List.NonEmpty as NE
 
 import Xmobar.System.Signal
 import Xmobar.Config.Types
@@ -52,6 +53,7 @@ import Xmobar.X11.Text
 import Xmobar.X11.Draw
 import Xmobar.X11.Bitmap as Bitmap
 import Xmobar.X11.Types
+import Xmobar.System.Utils (safeIndex)
 
 #ifndef THREADED_RUNTIME
 import Xmobar.X11.Events(nextEvent')
@@ -208,7 +210,7 @@ eventLoop tv xc@(XConf d r w fs vos is cfg) as signal = do
             eventLoop tv xc as signal
 
         reposWindow rcfg = do
-          r' <- repositionWin d w (head fs) rcfg
+          r' <- repositionWin d w (NE.head fs) rcfg
           eventLoop tv (XConf d r' w fs vos is rcfg) as signal
 
         updateConfigPosition ocfg =
@@ -262,7 +264,7 @@ updateActions conf (Rectangle _ _ wid _) ~[left,center,right] = do
       strLn :: [(Widget, String, Int, Maybe [Action])] -> IO [(Maybe [Action], Position, Position)]
       strLn  = liftIO . mapM getCoords
       iconW i = maybe 0 Bitmap.width (lookup i $ iconS conf)
-      getCoords (Text s,_,i,a) = textWidth d (fs!!i) s >>= \tw -> return (a, 0, fi tw)
+      getCoords (Text s,_,i,a) = textWidth d (safeIndex fs i) s >>= \tw -> return (a, 0, fi tw)
       getCoords (Icon s,_,_,a) = return (a, 0, fi $ iconW s)
       partCoord off xs = map (\(a, x, x') -> (fromJust a, x, x')) $
                          filter (\(a, _,_) -> isJust a) $

--- a/src/Xmobar/App/Main.hs
+++ b/src/Xmobar/App/Main.hs
@@ -29,6 +29,7 @@ import System.Environment (getArgs)
 import System.FilePath
 import System.FilePath.Posix (takeBaseName, takeDirectory)
 import Text.Parsec.Error (ParseError)
+import Data.List.NonEmpty (NonEmpty(..))
 
 import Graphics.X11.Xlib
 
@@ -63,7 +64,7 @@ xmobar conf = withDeferSignals $ do
       let ic = Map.empty
           to = textOffset conf
           ts = textOffsets conf ++ replicate (length fl) (-1)
-      startLoop (XConf d r w (fs:fl) (to:ts) ic conf) sig refLock vars
+      startLoop (XConf d r w (fs :| fl) (to:ts) ic conf) sig refLock vars
 
 configFromArgs :: Config -> IO Config
 configFromArgs cfg = getArgs >>= getOpts >>= doOpts cfg . fst

--- a/src/Xmobar/System/Utils.hs
+++ b/src/Xmobar/System/Utils.hs
@@ -17,11 +17,16 @@
 ------------------------------------------------------------------------------
 
 
-module Xmobar.System.Utils (expandHome, changeLoop, onSomeException)
-where
+module Xmobar.System.Utils
+  ( expandHome
+  , changeLoop
+  , onSomeException
+  , safeIndex
+  ) where
 
 import Control.Monad
 import Control.Concurrent.STM
+import qualified Data.List.NonEmpty as NE
 
 import System.Environment
 import System.FilePath
@@ -50,3 +55,18 @@ onSomeException :: IO a -> (SomeException -> IO b) -> IO a
 onSomeException io what = io `catch` \e -> do _ <- what e
                                               throwIO (e :: SomeException)
 
+(!!?) :: [a] -> Int -> Maybe a
+(!!?) xs i
+    | i < 0     = Nothing
+    | otherwise = go i xs
+  where
+    go :: Int -> [a] -> Maybe a
+    go 0 (x:_)  = Just x
+    go j (_:ys) = go (j - 1) ys
+    go _ []     = Nothing
+{-# INLINE (!!?) #-}
+
+safeIndex :: NE.NonEmpty a -> Int -> a
+safeIndex xs index = case (NE.toList xs) !!? index of
+                       Nothing -> NE.head xs
+                       Just value -> value

--- a/src/Xmobar/X11/Parsers.hs
+++ b/src/Xmobar/X11/Parsers.hs
@@ -21,6 +21,7 @@ import Xmobar.X11.Actions
 
 import Control.Monad (guard, mzero)
 import Text.ParserCombinators.Parsec
+import Text.Read (readMaybe)
 import Graphics.X11.Types (Button)
 
 data Widget = Icon String | Text String
@@ -138,7 +139,7 @@ fontParser :: ColorString -> Maybe [Action]
               -> Parser [(Widget, ColorString, FontIndex, Maybe [Action])]
 fontParser c a = do
   f <- between (string "<fn=") (string ">") colors
-  s <- manyTill (allParsers c (read f) a) (try $ string "</fn>")
+  s <- manyTill (allParsers c (maybe 0 id $ readMaybe f) a) (try $ string "</fn>")
   return (concat s)
 
 -- | Parses a color specification (hex or named)

--- a/src/Xmobar/X11/Types.hs
+++ b/src/Xmobar/X11/Types.hs
@@ -20,6 +20,7 @@ module Xmobar.X11.Types (X, XConf (..)) where
 import Graphics.X11.Xlib
 import Control.Monad.Reader
 import Data.Map
+import qualified Data.List.NonEmpty as NE
 
 import Xmobar.X11.Bitmap
 import Xmobar.X11.Text
@@ -33,7 +34,7 @@ data XConf =
     XConf { display   :: Display
           , rect      :: Rectangle
           , window    :: Window
-          , fontListS :: [XFont]
+          , fontListS :: NE.NonEmpty XFont
           , verticalOffsets :: [Int]
           , iconS     :: Map FilePath Bitmap
           , config    :: Config


### PR DESCRIPTION
Right now, with the `StdinReader` plugin enabled - you can crash/cause
busy looping of xmobar if the following html file is opened:

```
<html>
<head>
  <title>hello <fn=1>string</fn> </title>
</head>
</html>
```

More details about this bug is here:
https://github.com/jaor/xmobar/issues/442#issuecomment-625706001

This MR also fixes another bug which produces a crash in xmobar if you
pass non integer items between fn:

<fn=crash>