### PR TITLE
Optimize weather plugin by reusing manager and other refactors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ _New features_
   - Optimize date plugin by avoiding calling getTimeZone for each of
     the time the date has to be updated. Instead, it's computed once
     at the start and re-used for each invocation.
+  - Optimize Weather and UVMeter plugin by using global Manager instead of
+    creating for each http request when useManager is explicitly configured as False.
 
 ## Version 0.33 (February, 2020)
 

--- a/src/Xmobar/Plugins/Monitors/Weather.hs
+++ b/src/Xmobar/Plugins/Monitors/Weather.hs
@@ -31,7 +31,7 @@ import System.Console.GetOpt (ArgDescr(ReqArg), OptDescr(Option))
 
 
 -- | Options the user may specify.
-data WeatherOpts = WeatherOpts
+newtype WeatherOpts = WeatherOpts
   { weatherString :: String
   }
 

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -263,7 +263,7 @@ library
     if flag(with_weather) || flag(all_extensions)
        other-modules: Xmobar.Plugins.Monitors.Weather
        cpp-options: -DWEATHER
-       build-depends: http-conduit, http-types
+       build-depends: http-conduit, http-types, http-client-tls
 
     if flag(with_uvmeter)
        other-modules: Xmobar.Plugins.Monitors.UVMeter


### PR DESCRIPTION
As documented in the http-client library, calling newManager is an
expensive operation:

```
Creating a new Manager is a relatively expensive operation, you are
advised to share a single Manager between requests instead.
```

But inspite of the haddocks in xmobar claiming that once 'Manager' is
created, it will be used throughout the monitor is not true. Because for
every call of `startWeather` a new manager is being created.

Also I removed the option in WeatherOpts because even if it is false,
it will be ultimately created in `getData` function. Also without
using a manager - the plugin won't really work. So, I don't think
there is any reason for this option to exist.

I have introduced a new dependency http-client-tls to use the shared
global manager so that we reuse the same manager every time. This
simplifies a lot of code. Note that this is not really a new
dependency because http-conduit already depends on it transitively.