### PR TITLE
Optimize startCommand

### DIFF
--- a/src/Xmobar/App/EventLoop.hs
+++ b/src/Xmobar/App/EventLoop.hs
@@ -245,9 +245,8 @@ startCommand sig (com,s,ss)
     | otherwise = do var <- atomically $ newTVar is
                      let cb str = atomically $ writeTVar var (s ++ str ++ ss)
                      a1 <- async $ start com cb
-                     a2 <- async $ trigger com $ maybe (return ())
-                                                 (atomically . putTMVar sig)
-                     return ([a1, a2], var)
+                     trigger com $ maybe (return ()) (atomically . putTMVar sig)
+                     return ([a1], var)
     where is = s ++ "Updating..." ++ ss
 
 updateString :: Config -> TVar [String]

--- a/src/Xmobar/Plugins/BufferedPipeReader.hs
+++ b/src/Xmobar/Plugins/BufferedPipeReader.hs
@@ -16,6 +16,7 @@ module Xmobar.Plugins.BufferedPipeReader(BufferedPipeReader(..)) where
 
 import Control.Monad(forM_, when, void)
 import Control.Concurrent
+import Control.Concurrent.Async (withAsync, wait)
 import Control.Concurrent.STM
 import System.IO
 import System.IO.Unsafe(unsafePerformIO)
@@ -35,7 +36,9 @@ instance Exec BufferedPipeReader where
     alias      ( BufferedPipeReader a _  )    = a
 
     trigger br@( BufferedPipeReader _ _  ) sh =
-        takeMVar signal >>= sh . Just >> trigger br sh
+        let action = newTrigger br sh
+            newTrigger br2 sh2 = takeMVar signal >>= sh2 . Just >> newTrigger br2 sh2
+        in withAsync action wait
 
     start      ( BufferedPipeReader _ ps ) cb = do
 


### PR DESCRIPTION
For every monitor in xmobar, we currently spawn two threads during
startup. But one of the threads from it get's exited as soon as it's
started because this is the default definition of trigger:

```
    trigger :: e -> (Maybe SignalType -> IO ()) -> IO ()
    trigger _ sh  = sh Nothing
```

So, for the `Nothing`, the expression `maybe (return ()) (atomically
. putTMVar sig)` evaluates to `()` and returns immediately. The only
place where this seems to be required is the `BufferedPipeReader`
plugin. I'm moving the spawing of the green thread to that plugin
itself so as to avoid this overhead for the other monitors where this
isn't used.

Fixes https://github.com/jaor/xmobar/issues/451