### PR TITLE
Initial support for benchmarks of the plugins

### DIFF
--- a/bench/main.hs
+++ b/bench/main.hs
@@ -1,0 +1,44 @@
+{-#LANGUAGE RecordWildCards#-}
+
+import Gauge
+import Xmobar
+import Xmobar.Plugins.Monitors.Common.Types
+import Xmobar.Plugins.Monitors.Common.Run
+import Xmobar.Plugins.Monitors.Cpu
+import Control.Monad.Reader
+import Data.IORef (newIORef)
+
+main :: IO ()
+main = do
+  cpuParams <- mkCpuArgs
+  defaultMain $ normalBench cpuParams
+    where
+      normalBench args = [ bgroup "Cpu Benchmarks" $ normalCpuBench args]
+
+runMonitor :: MConfig -> Monitor a -> IO a
+runMonitor config r = runReaderT r config
+
+data CpuArguments = CpuArguments {
+      cpuRef :: CpuDataRef,
+      cpuMConfig :: MConfig,
+      cpuArgs :: [String]
+    }
+
+mkCpuArgs :: IO CpuArguments
+mkCpuArgs = do
+  cpuRef <- newIORef []
+  _ <- parseCpu cpuRef
+  cpuMConfig <- cpuConfig
+  let cpuArgs = ["-L","3","-H","50","--normal","green","--high","red"]
+  pure $ CpuArguments {..}
+
+-- | The action which will be benchmarked
+cpuAction :: CpuArguments -> IO String
+cpuAction CpuArguments{..} = runMonitor cpuMConfig (doArgs cpuArgs (runCpu cpuRef) (\_ -> return True))
+
+
+cpuBenchmark :: CpuArguments -> Benchmarkable
+cpuBenchmark cpuParams = nfIO $ cpuAction cpuParams
+
+normalCpuBench :: CpuArguments -> [Benchmark]
+normalCpuBench args = [bench "CPU normal args" (cpuBenchmark args)]

--- a/src/Xmobar/Plugins/Monitors/Common/Run.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Run.hs
@@ -22,6 +22,7 @@ module Xmobar.Plugins.Monitors.Common.Run ( runM
                                           , runML
                                           , runMLD
                                           , getArgvs
+                                          , doArgs
                                           ) where
 
 import Control.Exception (SomeException,handle)
@@ -35,8 +36,8 @@ import Xmobar.Run.Exec (doEveryTenthSeconds)
 options :: [OptDescr Opts]
 options =
     [
-      Option "H" ["High"] (ReqArg High "number") "The high threshold"
-    , Option "L" ["Low"] (ReqArg Low "number") "The low threshold"
+      Option ['H'] ["High"] (ReqArg High "number") "The high threshold"
+    , Option ['L'] ["Low"] (ReqArg Low "number") "The low threshold"
     , Option "h" ["high"] (ReqArg HighColor "color number") "Color for the high threshold: ex \"#FF0000\""
     , Option "n" ["normal"] (ReqArg NormalColor "color number") "Color for the normal threshold: ex \"#00FF00\""
     , Option "l" ["low"] (ReqArg LowColor "color number") "Color for the low threshold: ex \"#0000FF\""

--- a/src/Xmobar/Plugins/Monitors/Cpu.hs
+++ b/src/Xmobar/Plugins/Monitors/Cpu.hs
@@ -13,7 +13,7 @@
 --
 -----------------------------------------------------------------------------
 
-module Xmobar.Plugins.Monitors.Cpu (startCpu) where
+module Xmobar.Plugins.Monitors.Cpu (startCpu, runCpu, cpuConfig, CpuDataRef, parseCpu) where
 
 import Xmobar.Plugins.Monitors.Common
 import qualified Data.ByteString.Lazy.Char8 as B

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -95,7 +95,10 @@ library
     default-language: Haskell2010
     hs-source-dirs:  src
 
-    exposed-modules: Xmobar
+    exposed-modules: Xmobar,
+                     Xmobar.Plugins.Monitors.Common.Types,
+                     Xmobar.Plugins.Monitors.Common.Run,
+                     Xmobar.Plugins.Monitors.Cpu
 
     other-modules: Paths_xmobar,
                    Xmobar.Config.Types,
@@ -140,14 +143,11 @@ library
                    Xmobar.Plugins.Monitors,
                    Xmobar.Plugins.Monitors.Batt,
                    Xmobar.Plugins.Monitors.Common,
-                   Xmobar.Plugins.Monitors.Common.Types,
-                   Xmobar.Plugins.Monitors.Common.Run,
                    Xmobar.Plugins.Monitors.Common.Output,
                    Xmobar.Plugins.Monitors.Common.Parsers,
                    Xmobar.Plugins.Monitors.Common.Files,
                    Xmobar.Plugins.Monitors.CoreTemp,
                    Xmobar.Plugins.Monitors.CpuFreq,
-                   Xmobar.Plugins.Monitors.Cpu,
                    Xmobar.Plugins.Monitors.Disk,
                    Xmobar.Plugins.Monitors.Mem,
                    Xmobar.Plugins.Monitors.MultiCoreTemp,
@@ -331,7 +331,6 @@ test-suite XmobarTest
   other-modules: Xmobar.Plugins.Monitors.CommonSpec
                  Xmobar.Plugins.Monitors.Common
                  Xmobar.Plugins.Monitors.Common.Parsers
-                 Xmobar.Plugins.Monitors.Common.Run
                  Xmobar.Plugins.Monitors.Common.Types
                  Xmobar.Plugins.Monitors.Common.Output
                  Xmobar.Plugins.Monitors.Common.Files
@@ -348,3 +347,12 @@ test-suite XmobarTest
                      Xmobar.Plugins.Monitors.AlsaSpec
 
       cpp-options: -DALSA
+
+benchmark xmobarbench
+  type: exitcode-stdio-1.0
+  main-is: main.hs
+  hs-source-dirs:
+      bench
+  ghc-options: -O2
+  build-depends: base, gauge, xmobar, mtl
+  default-language: Haskell2010


### PR DESCRIPTION
This MR adds the initial infrastructure for the benchmarking of the plugins. Right now it's quite hard to measure things and see if something is actually causing any improvements here.

This is the output you get right now with this MR:
```
$ stack bench
benchmarked Cpu Benchmarks/CPU normal args
time                 100.5 μs   (99.87 μs .. 100.8 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 102.2 μs   (101.7 μs .. 103.4 μs)
std dev              2.377 μs   (1.009 μs .. 4.864 μs)

Benchmark xmobarbench: FINISH
Completed 2 action(s).
```

Note that this is initial MR and we should improve this further by adding benchmark for various other monitors.