### PR TITLE
Optimize CPU Monitor: 25% perf boosts and other changes

### DIFF
--- a/bench/main.hs
+++ b/bench/main.hs
@@ -18,24 +18,12 @@ main = do
 runMonitor :: MConfig -> Monitor a -> IO a
 runMonitor config r = runReaderT r config
 
-data CpuArguments = CpuArguments {
-      cpuRef :: CpuDataRef,
-      cpuMConfig :: MConfig,
-      cpuArgs :: [String]
-    }
-
 mkCpuArgs :: IO CpuArguments
-mkCpuArgs = do
-  cpuRef <- newIORef []
-  _ <- parseCpu cpuRef
-  cpuMConfig <- cpuConfig
-  let cpuArgs = ["-L","3","-H","50","--normal","green","--high","red"]
-  pure $ CpuArguments {..}
-
+mkCpuArgs = getArguments ["-L","3","-H","50","--normal","green","--high","red", "-t", "Cpu: <total>%"]
+  
 -- | The action which will be benchmarked
 cpuAction :: CpuArguments -> IO String
-cpuAction CpuArguments{..} = runMonitor cpuMConfig (doArgs cpuArgs (runCpu cpuRef) (\_ -> return True))
-
+cpuAction = runCpu
 
 cpuBenchmark :: CpuArguments -> Benchmarkable
 cpuBenchmark cpuParams = nfIO $ cpuAction cpuParams

--- a/src/Xmobar/Plugins/Monitors/Common/Output.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Output.hs
@@ -101,8 +101,8 @@ pSetColor config str s =
             Just c -> "<fc=" ++ c ++ ">" ++ str ++ "</fc>"
 
 pShowWithPadding :: MonitorConfig -> String -> String
-pShowWithPadding MonitorConfig {..} s =
-  padString pMinWidth pMaxWidth pPadChars pPadRight pMaxWidthEllipsis s
+pShowWithPadding MonitorConfig {..} =
+  padString pMinWidth pMaxWidth pPadChars pPadRight pMaxWidthEllipsis
 
 pFloatToPercent :: MonitorConfig -> Float -> String
 pFloatToPercent MonitorConfig{..} n = let p = showDigits 0 (n * 100)

--- a/src/Xmobar/Plugins/Monitors/Common/Output.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Output.hs
@@ -43,6 +43,7 @@ module Xmobar.Plugins.Monitors.Common.Output ( IconPattern
                                              , pShowPercentBar
                                              , pShowVerticalBar
                                              , pShowIconPattern
+                                             , pShowPercentWithColors
                                              ) where
 
 import Data.Char

--- a/src/Xmobar/Plugins/Monitors/Common/Parsers.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Parsers.hs
@@ -41,8 +41,8 @@ import qualified Data.Map as Map
 import System.Console.GetOpt (ArgOrder(Permute), OptDescr, getOpt)
 import Text.ParserCombinators.Parsec
 
-runTemplateParser :: PureConfig -> IO [(String, String, String)]
-runTemplateParser PureConfig{..} = runP templateParser pTemplate
+runTemplateParser :: MonitorConfig -> IO [(String, String, String)]
+runTemplateParser MonitorConfig{..} = runP templateParser pTemplate
 
 runExportParser :: [String] -> IO [(String, [(String, String,String)])]
 runExportParser [] = pure []
@@ -51,8 +51,8 @@ runExportParser (x:xs) = do
   rest <- runExportParser xs
   pure $ (x,s):rest
 
-pureParseTemplate :: PureConfig -> TemplateInput -> IO String
-pureParseTemplate PureConfig{..} TemplateInput{..} =
+pureParseTemplate :: MonitorConfig -> TemplateInput -> IO String
+pureParseTemplate MonitorConfig{..} TemplateInput{..} =
     do let m = let expSnds :: [([(String, String, String)], String)]  = zip (map snd temAllTemplate) temMonitorValues
                in Map.fromList $ zip (map fst temAllTemplate) expSnds
        s <- minCombine m temInputTemplate

--- a/src/Xmobar/Plugins/Monitors/Common/Parsers.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Parsers.hs
@@ -54,7 +54,7 @@ runExportParser (x:xs) = do
 pureParseTemplate :: PureConfig -> TemplateInput -> IO String
 pureParseTemplate PureConfig{..} TemplateInput{..} =
     do let m = let expSnds :: [([(String, String, String)], String)]  = zip (map snd temAllTemplate) temMonitorValues
-               in Map.fromList $ zip (map fst temAllTemplate) $ expSnds
+               in Map.fromList $ zip (map fst temAllTemplate) expSnds
        s <- minCombine m temInputTemplate
        let (n, s') = if pMaxTotalWidth > 0 && length s > pMaxTotalWidth
                      then trimTo (pMaxTotalWidth - length pMaxTotalWidthEllipsis) "" s

--- a/src/Xmobar/Plugins/Monitors/Common/Run.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Run.hs
@@ -24,7 +24,7 @@ module Xmobar.Plugins.Monitors.Common.Run ( runM
                                           , getArgvs
                                           , doArgs
                                           , computePureConfig
-                                          , commonOptions
+                                          , pluginOptions
                                           ) where
 
 import Control.Exception (SomeException,handle)
@@ -35,10 +35,8 @@ import System.Console.GetOpt
 import Xmobar.Plugins.Monitors.Common.Types
 import Xmobar.Run.Exec (doEveryTenthSeconds)
 
-commonOptions = options
-
-options :: [OptDescr Opts]
-options =
+pluginOptions :: [OptDescr Opts]
+pluginOptions =
     [
       Option ['H'] ["High"] (ReqArg High "number") "The high threshold"
     , Option ['L'] ["Low"] (ReqArg Low "number") "The low threshold"
@@ -66,7 +64,7 @@ options =
 -- | Get all argument values out of a list of arguments.
 getArgvs :: [String] -> [String]
 getArgvs args =
-    case getOpt Permute options args of
+    case getOpt Permute pluginOptions args of
         (_, n, []  ) -> n
         (_, _, errs) -> errs
 
@@ -77,7 +75,7 @@ doArgs :: [String]
        -> ([String] -> Monitor Bool)
        -> Monitor String
 doArgs args action detect =
-    case getOpt Permute options args of
+    case getOpt Permute pluginOptions args of
       (o, n, [])   -> do doConfigOptions o
                          ready <- detect n
                          if ready
@@ -158,6 +156,6 @@ getMConfig args mconfig = do
   runReaderT (updateOptions args >> ask) config
 
 updateOptions :: [String] -> Monitor ()
-updateOptions args= case getOpt Permute options args of
+updateOptions args= case getOpt Permute pluginOptions args of
                       (o, _, []) -> doConfigOptions o
                       _ -> return ()

--- a/src/Xmobar/Plugins/Monitors/Common/Run.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Run.hs
@@ -23,7 +23,7 @@ module Xmobar.Plugins.Monitors.Common.Run ( runM
                                           , runMLD
                                           , getArgvs
                                           , doArgs
-                                          , computePureConfig
+                                          , computeMonitorConfig
                                           , pluginOptions
                                           ) where
 
@@ -145,10 +145,10 @@ runMLD args conf action looper detect cb = handle (cb . showException) loop
 showException :: SomeException -> String
 showException = ("error: "++) . show . flip asTypeOf undefined
 
-computePureConfig :: [String] -> IO MConfig -> IO PureConfig
-computePureConfig args mconfig = do
+computeMonitorConfig :: [String] -> IO MConfig -> IO MonitorConfig
+computeMonitorConfig args mconfig = do
   newConfig <- getMConfig args mconfig
-  getPureConfig newConfig
+  getMonitorConfig newConfig
 
 getMConfig :: [String] -> IO MConfig -> IO MConfig
 getMConfig args mconfig = do

--- a/src/Xmobar/Plugins/Monitors/Common/Types.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Types.hs
@@ -22,7 +22,6 @@ module Xmobar.Plugins.Monitors.Common.Types ( Monitor
                                             , Opts (..)
                                             , Selector
                                             , setConfigValue
-                                            , getConfigValue
                                             , mkMConfig
                                             , io
                                             , PureConfig (..)
@@ -134,10 +133,6 @@ sel :: Selector a -> Monitor a
 sel s =
     do hs <- ask
        liftIO $ readIORef (s hs)
-
-pmods :: PureConfig -> PSelector a -> (a -> a) -> a
-pmods config value f = let val = value config
-                       in f val
 
 mods :: Selector a -> (a -> a) -> Monitor ()
 mods s m =

--- a/src/Xmobar/Plugins/Monitors/Common/Types.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Types.hs
@@ -24,10 +24,10 @@ module Xmobar.Plugins.Monitors.Common.Types ( Monitor
                                             , setConfigValue
                                             , mkMConfig
                                             , io
-                                            , PureConfig (..)
+                                            , MonitorConfig (..)
                                             , getPConfigValue
                                             , getConfigValue
-                                            , getPureConfig
+                                            , getMonitorConfig
                                             , PSelector
                                             , TemplateInput(..)
                                             ) where
@@ -71,8 +71,8 @@ data MConfig =
        , maxTotalWidthEllipsis :: IORef String
        }
 
-data PureConfig =
-  PureConfig
+data MonitorConfig =
+  MonitorConfig
     { pNormalColor :: Maybe String
     , pLow :: Int
     , pLowColor :: Maybe String
@@ -97,8 +97,8 @@ data PureConfig =
     }
   deriving (Eq, Ord)
 
-getPureConfig :: MConfig -> IO PureConfig
-getPureConfig MC{..} = do
+getMonitorConfig :: MConfig -> IO MonitorConfig
+getMonitorConfig MC{..} = do
   pNormalColor <- readIORef normalColor
   pLow <- readIORef low
   pLowColor <- readIORef lowColor
@@ -120,13 +120,13 @@ getPureConfig MC{..} = do
   pNaString <- readIORef naString
   pMaxTotalWidth <- readIORef maxTotalWidth
   pMaxTotalWidthEllipsis <- readIORef maxTotalWidthEllipsis
-  pure $ PureConfig {..}
+  pure $ MonitorConfig {..}
 
 -- | from 'http:\/\/www.haskell.org\/hawiki\/MonadState'
 type Selector a = MConfig -> IORef a
-type PSelector a = PureConfig -> a
+type PSelector a = MonitorConfig -> a
 
-psel :: PureConfig -> PSelector a -> a
+psel :: MonitorConfig -> PSelector a -> a
 psel value accessor = accessor value
 
 sel :: Selector a -> Monitor a
@@ -146,7 +146,7 @@ setConfigValue v s =
 getConfigValue :: Selector a -> Monitor a
 getConfigValue = sel
 
-getPConfigValue :: PureConfig -> PSelector a -> a
+getPConfigValue :: MonitorConfig -> PSelector a -> a
 getPConfigValue = psel
 
 mkMConfig :: String

--- a/src/Xmobar/Plugins/Monitors/Common/Types.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Types.hs
@@ -73,11 +73,11 @@ data MConfig =
 
 data PureConfig =
   PureConfig
-    { pNormalColor :: (Maybe String)
+    { pNormalColor :: Maybe String
     , pLow :: Int
-    , pLowColor :: (Maybe String)
+    , pLowColor :: Maybe String
     , pHigh :: Int
-    , pHighColor :: (Maybe String)
+    , pHighColor :: Maybe String
     , pTemplate :: String
     , pExport :: [String]
     , pPpad :: Int

--- a/src/Xmobar/Plugins/Monitors/Cpu.hs
+++ b/src/Xmobar/Plugins/Monitors/Cpu.hs
@@ -138,12 +138,6 @@ parseCpu cref =
            percent = map safeDiv dif
        return $ convertToCpuData percent
 
-conditionalCompute :: [String] -> String -> IO String -> IO String
-conditionalCompute allFields field action = if field `elem` allFields
-                                            then action
-                                            else pure []
-
-
 data Field = Field {
       fieldName :: !String,
       fieldCompute :: !ShouldCompute
@@ -187,8 +181,8 @@ computeFields (x:xs) inputFields =
     else (Field {fieldName = x, fieldCompute = Skip}) : (computeFields xs inputFields)
 
 formatCpu :: CpuArguments -> CpuData -> IO [String]
-formatCpu args@CpuArguments{..} cpuData = do
-  strs <- mapM (formatField cpuParams cpuOpts cpuData) cpuFields
+formatCpu CpuArguments{..} cpuInfo = do
+  strs <- mapM (formatField cpuParams cpuOpts cpuInfo) cpuFields
   pure $ filter (not . null) strs
 
 getInputFields :: CpuArguments -> [String]
@@ -214,7 +208,7 @@ getArguments :: [String] -> IO CpuArguments
 getArguments cpuArgs = do
   initCpuData <- cpuData
   cpuDataRef <- newIORef initCpuData
-  cpuData <- parseCpu cpuDataRef
+  void $ parseCpu cpuDataRef
   cpuParams <- computePureConfig cpuArgs cpuConfig
   cpuInputTemplate <- runTemplateParser cpuParams
   cpuAllTemplate <- runExportParser (pExport cpuParams)

--- a/src/Xmobar/Plugins/Monitors/Cpu.hs
+++ b/src/Xmobar/Plugins/Monitors/Cpu.hs
@@ -43,10 +43,15 @@ cpuConfig = mkMConfig
 type CpuDataRef = IORef [Int]
 
 cpuData :: IO [Int]
-cpuData = cpuParser `fmap` B.readFile "/proc/stat"
+cpuData = cpuParser <$> B.readFile "/proc/stat"
+
+readInt :: B.ByteString -> Int
+readInt bs = case B.readInt bs of
+               Nothing -> 0
+               Just (i, _) -> i
 
 cpuParser :: B.ByteString -> [Int]
-cpuParser = map (read . B.unpack) . tail . B.words . head . B.lines
+cpuParser = map readInt . tail . B.words . head . B.lines
 
 parseCpu :: CpuDataRef -> IO [Float]
 parseCpu cref =

--- a/src/Xmobar/Plugins/Monitors/Cpu.hs
+++ b/src/Xmobar/Plugins/Monitors/Cpu.hs
@@ -145,7 +145,7 @@ data Field = Field {
 
 data ShouldCompute = Compute | Skip deriving (Eq, Ord, Show)
 
-formatField :: PureConfig -> CpuOpts -> CpuData -> Field -> IO String
+formatField :: MonitorConfig -> CpuOpts -> CpuData -> Field -> IO String
 formatField cpuParams cpuOpts cpuInfo@CpuData {..} Field {..}
   | fieldName == barField =
     if fieldCompute == Compute
@@ -203,7 +203,7 @@ optimizeAllTemplate args@CpuArguments {..} =
 data CpuArguments =
   CpuArguments
     { cpuDataRef :: !CpuDataRef
-    , cpuParams :: !PureConfig
+    , cpuParams :: !MonitorConfig
     , cpuArgs :: ![String]
     , cpuOpts :: !CpuOpts
     , cpuInputTemplate :: ![(String, String, String)] -- [("Cpu: ","total","% "),("","user","%")]
@@ -217,7 +217,7 @@ getArguments cpuArgs = do
   initCpuData <- cpuData
   cpuDataRef <- newIORef initCpuData
   void $ parseCpu cpuDataRef
-  cpuParams <- computePureConfig cpuArgs cpuConfig
+  cpuParams <- computeMonitorConfig cpuArgs cpuConfig
   cpuInputTemplate <- runTemplateParser cpuParams
   cpuAllTemplate <- runExportParser (pExport cpuParams)
   nonOptions <-

--- a/src/Xmobar/Plugins/Monitors/Cpu.hs
+++ b/src/Xmobar/Plugins/Monitors/Cpu.hs
@@ -134,7 +134,7 @@ parseCpu cref =
            tot = fromIntegral $ sum dif
            safeDiv n = case tot of
                          0 -> 0
-                         v -> (fromIntegral n) / v
+                         v -> fromIntegral n / v
            percent = map safeDiv dif
        return $ convertToCpuData percent
 
@@ -181,9 +181,9 @@ computeFields [] _ = []
 computeFields (x:xs) inputFields =
   if x `elem` inputFields
     then (Field {fieldName = x, fieldCompute = Compute}) :
-         (computeFields xs inputFields)
+         computeFields xs inputFields
     else (Field {fieldName = x, fieldCompute = Skip}) :
-         (computeFields xs inputFields)
+         computeFields xs inputFields
 
 formatCpu :: CpuArguments -> CpuData -> IO [String]
 formatCpu CpuArguments{..} cpuInfo = do

--- a/src/Xmobar/Plugins/Monitors/Cpu.hs
+++ b/src/Xmobar/Plugins/Monitors/Cpu.hs
@@ -114,11 +114,11 @@ data CpuData = CpuData {
     }
 
 convertToCpuData :: [Float] -> CpuData
-convertToCpuData (u:n:s:id:iw:_) = CpuData {
+convertToCpuData (u:n:s:ie:iw:_) = CpuData {
                                    cpuUser = u,
                                    cpuNice = n,
                                    cpuSystem = s,
-                                   cpuIdle = id,
+                                   cpuIdle = ie,
                                    cpuIowait = iw,
                                    cpuTotal = sum [u,n,s]
                                  }
@@ -212,7 +212,7 @@ getArguments cpuArgs = do
   cpuParams <- computePureConfig cpuArgs cpuConfig
   cpuInputTemplate <- runTemplateParser cpuParams
   cpuAllTemplate <- runExportParser (pExport cpuParams)
-  nonOptions <- case getOpt Permute commonOptions cpuArgs of
+  nonOptions <- case getOpt Permute pluginOptions cpuArgs of
                   (_, n, []) -> pure n
                   (_,_,errs) -> error $ "getArguments: " <> show errs
   cpuOpts <- case getOpt Permute options nonOptions of

--- a/test/Xmobar/Plugins/Monitors/CpuSpec.hs
+++ b/test/Xmobar/Plugins/Monitors/CpuSpec.hs
@@ -1,0 +1,41 @@
+module Xmobar.Plugins.Monitors.CpuSpec
+  ( 
+   spec, main
+  ) where
+
+import Test.Hspec
+import Xmobar.Plugins.Monitors.Common
+import Xmobar.Plugins.Monitors.Cpu
+import Data.List
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec =
+  describe "CPU Spec" $ do
+    it "works with total template" $
+      do let args = ["-L","3","-H","50","--normal","green","--high","red", "-t", "Cpu: <total>%"]
+         cpuArgs <- getArguments args
+         cpuValue <- runCpu cpuArgs
+         cpuValue `shouldSatisfy` (\item -> "Cpu:" `isPrefixOf` item)
+    it "works with bar template" $
+      do let args = ["-L","3","-H","50","--normal","green","--high","red", "-t", "Cpu: <total>% <bar>"]
+         cpuArgs <- getArguments args
+         cpuValue <- runCpu cpuArgs
+         cpuValue `shouldSatisfy` (\item -> "::" `isSuffixOf` item)
+    it "works with no icon pattern template" $
+      do let args = ["-L","3","-H","50","--normal","green","--high","red", "-t", "Cpu: <total>% <bar>", "--", "--load-icon-pattern", "<icon=bright_%%.xpm/>"]
+         cpuArgs <- getArguments args
+         cpuValue <- runCpu cpuArgs
+         cpuValue `shouldSatisfy` (\item -> not $ "<icon=bright_" `isInfixOf` cpuValue)
+    it "works with icon pattern template" $
+      do let args = ["-L","3","-H","50","--normal","green","--high","red", "-t", "Cpu: <total>% <bar> <ipat>", "--", "--load-icon-pattern", "<icon=bright_%%.xpm/>"]
+         cpuArgs <- getArguments args
+         cpuValue <- runCpu cpuArgs
+         cpuValue `shouldSatisfy` (\item -> "<icon=bright_" `isInfixOf` cpuValue)
+    it "works with other parameters in template" $
+      do let args = ["-L","3","-H","50","--normal","green","--high","red", "-t", "Cpu: <user> <nice> <iowait>"]
+         cpuArgs <- getArguments args
+         cpuValue <- runCpu cpuArgs
+         cpuValue `shouldSatisfy` (\item -> "Cpu:" `isPrefixOf` cpuValue)

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -334,6 +334,8 @@ test-suite XmobarTest
                  Xmobar.Plugins.Monitors.Common.Types
                  Xmobar.Plugins.Monitors.Common.Output
                  Xmobar.Plugins.Monitors.Common.Files
+                 Xmobar.Plugins.Monitors.Cpu
+                 Xmobar.Plugins.Monitors.Common.Run
                  Xmobar.Run.Exec
                  Xmobar.App.Timer
                  Xmobar.System.Signal
@@ -345,6 +347,7 @@ test-suite XmobarTest
       other-modules: Xmobar.Plugins.Monitors.Volume
                      Xmobar.Plugins.Monitors.Alsa
                      Xmobar.Plugins.Monitors.AlsaSpec
+                     Xmobar.Plugins.Monitors.CpuSpec
 
       cpp-options: -DALSA
 


### PR DESCRIPTION
Summary of the changes:

* Make the CPU monitor more type safe. Added various new types instead of having `[String]` and `[Float]` everywhere.
* Add test cases for the CPU monitor
* Introduce new type named `PureConfig`. This is a pure version of `MConfig` and the initial work has been done in this MR which will hopefully in the future remove the need of the whole `MConfig` type.
* Avoid template parsing for the components which won't be rendered
* Avoid formatting output for the components which won't be rendered
* Perf improvements:

Before:
```
benchmarked Cpu Benchmarks/CPU normal args
time                 101.6 μs   (100.8 μs .. 102.3 μs)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 103.0 μs   (102.4 μs .. 104.5 μs)
std dev              2.883 μs   (1.465 μs .. 5.154 μs)
variance introduced by outliers: 11% (moderately inflated)
```
After:
```
time                 75.80 μs   (75.15 μs .. 76.36 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 75.97 μs   (75.74 μs .. 76.41 μs)
std dev              1.057 μs   (666.6 ns .. 1.927 μs)
```
