### PR TITLE
Do conditional utf8 encoding

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@ _Bug fixes_
 
   - Documentation fixes (Tomáš Janoušek)
   - Don't get confused by empty configuration dirs (fixes #412)
+  - Xft rendering: Avoid encoding to UTF8 on all scenarios. This
+    causes issue to StdinReader monitor when the handle wasn't binary.
 
 ## Version 0.35.1 (June, 2020)
 

--- a/src/Xmobar/X11/MinXft.hsc
+++ b/src/Xmobar/X11/MinXft.hsc
@@ -164,7 +164,7 @@ foreign import ccall "XftDrawStringUtf8"
 drawXftString :: (Integral a1, Integral a) =>
                  AXftDraw -> AXftColor -> AXftFont -> a -> a1 -> String -> IO ()
 drawXftString d c f x y string =
-    withArrayLen (map fi (UTF8.encode string))
+    withArrayLen (map (fi . ord) string)
       (\len ptr -> cXftDrawStringUtf8 d c f (fi x) (fi y) ptr (fi len))
 
 drawXftString' :: AXftDraw ->

--- a/src/Xmobar/X11/MinXft.hsc
+++ b/src/Xmobar/X11/MinXft.hsc
@@ -161,11 +161,11 @@ withAXftDraw d p v c act = do
 foreign import ccall "XftDrawStringUtf8"
   cXftDrawStringUtf8 :: AXftDraw -> AXftColor -> AXftFont -> CInt -> CInt -> Ptr (#type FcChar8) -> CInt -> IO ()
 
+-- Fixes https://github.com/jaor/xmobar/issues/476
 utf8EncodeString :: Num b => String -> [b]
 utf8EncodeString str = if UTF8.isUTF8Encoded str
                        then map (fi . ord) str
                        else map fi (UTF8.encode str)
-
 
 drawXftString :: (Integral a1, Integral a) =>
                  AXftDraw -> AXftColor -> AXftFont -> a -> a1 -> String -> IO ()

--- a/src/Xmobar/X11/MinXft.hsc
+++ b/src/Xmobar/X11/MinXft.hsc
@@ -161,10 +161,16 @@ withAXftDraw d p v c act = do
 foreign import ccall "XftDrawStringUtf8"
   cXftDrawStringUtf8 :: AXftDraw -> AXftColor -> AXftFont -> CInt -> CInt -> Ptr (#type FcChar8) -> CInt -> IO ()
 
+utf8EncodeString :: Num b => String -> [b]
+utf8EncodeString str = if UTF8.isUTF8Encoded str
+                       then map (fi . ord) str
+                       else map fi (UTF8.encode str)
+
+
 drawXftString :: (Integral a1, Integral a) =>
                  AXftDraw -> AXftColor -> AXftFont -> a -> a1 -> String -> IO ()
 drawXftString d c f x y string =
-    withArrayLen (map (fi . ord) string)
+    withArrayLen (utf8EncodeString string)
       (\len ptr -> cXftDrawStringUtf8 d c f (fi x) (fi y) ptr (fi len))
 
 drawXftString' :: AXftDraw ->


### PR DESCRIPTION
With this change, xmobar should respect the data which it gets. Xmobar
should just render the data instead of trying to encode it.