### PR TITLE
additionalFonts command-line option: --add-font

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -483,6 +483,7 @@ xmobar --help):
       -v            --verbose              Emit verbose debugging messages
       -r            --recompile            Force recompilation (for Haskell FILE)
       -f font name  --font=font name       Font name
+      -N font name  --add-font=font name   Add to the list of additional fonts
       -w class      --wmclass=class        X11 WM_CLASS property
       -n name       --wmname=name          X11 WM_NAME property
       -B bg color   --bgcolor=bg color     Background color. Default black

--- a/src/Xmobar/App/Opts.hs
+++ b/src/Xmobar/App/Opts.hs
@@ -31,6 +31,7 @@ data Opts = Help
           | Recompile
           | Version
           | Font       String
+          | AddFont    String
           | BgColor    String
           | FgColor    String
           | Alpha      String
@@ -56,6 +57,7 @@ options =
     , Option "r" ["recompile"] (NoArg Recompile) "Force recompilation"
     , Option "V" ["version"] (NoArg Version) "Show version information"
     , Option "f" ["font"] (ReqArg Font "font name") "Font name"
+    , Option "N" ["add-font"] (ReqArg AddFont "font name") "Add to the list of additional fonts"
     , Option "w" ["wmclass"] (ReqArg WmClass "class") "X11 WM_CLASS property"
     , Option "n" ["wmname"] (ReqArg WmName "name") "X11 WM_NAME property"
     , Option "B" ["bgcolor"] (ReqArg BgColor "bg color" )
@@ -127,6 +129,7 @@ doOpts conf (o:oo) =
     Recompile -> doOpts' conf
     Verbose -> doOpts' (conf {verbose = True})
     Font s -> doOpts' (conf {font = s})
+    AddFont s -> doOpts' (conf {additionalFonts = additionalFonts conf ++ [s]})
     WmClass s -> doOpts' (conf {wmClass = s})
     WmName s -> doOpts' (conf {wmName = s})
     BgColor s -> doOpts' (conf {bgColor = s})


### PR DESCRIPTION
Provide an option the user can specify (any number of times) to add to the `additionalFonts` config field.

___

I've been using this without issue for a couple days now. The screenshot below shows part of my status bar, including a couple font awesome characters (the lock icon indicating vpn status and speaker icon next to the volume indicator), achieved using
```
-N 'xft:FontAwesome:size=11'
```
and `<fn=1>...</fn>`.

![image](https://user-images.githubusercontent.com/1672874/93890959-e4247d00-fcb8-11ea-9958-b0d2b18731be.png)