### PR TITLE
update libmpd to 0.9.2.0

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ flags:
 
 extra-deps:
  - netlink-1.1.1.0
-
+ - libmpd-0.9.2.0
 nix:
     packages:
       - alsaLib

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -229,7 +229,7 @@ library
        cpp-options: -DUSE_NL80211
 
     if flag(with_mpd) || flag(all_extensions)
-       build-depends: libmpd >= 0.9.0.10
+       build-depends: libmpd >= 0.9.2.0
        other-modules: Xmobar.Plugins.Monitors.MPD
        cpp-options: -DLIBMPD
 


### PR DESCRIPTION
The update was needed to display MPD status with MPD 0.22+.