### PR TITLE
Fix for broken DateZone monitor

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-# ghc 8.6.5
-resolver: lts-14.20
+# ghc 8.8.3
+resolver: lts-16.0
 
 packages:
  - .

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -242,7 +242,7 @@ library
        cpp-options: -DALSA
 
     if flag(with_datezone) || flag(all_extensions)
-       build-depends: timezone-olson >= 0.1 && < 0.3, timezone-series == 0.1.*
+       build-depends: timezone-olson >= 0.2 && < 0.3, timezone-series == 0.1.*
        other-modules: Xmobar.Plugins.DateZone
        cpp-options: -DDATEZONE
 


### PR DESCRIPTION
There's a longstanding bug in timezone-olson that causes it to fail to
read some zoneinfo files (but not all, oddly). This was resolved in
timezone-olson-0.2.0 which can be built against by using a later
Stackage snapshot than master currently points to.

This fix pushes the snapshot up to lts-16.0 and also modifies the
cabal version range for timezone-olson to set 0.2.0 as the minimum.