### PR TITLE
Date: current time zone

### DIFF
--- a/src/Xmobar/Plugins/Date.hs
+++ b/src/Xmobar/Plugins/Date.hs
@@ -32,15 +32,12 @@ data Date = Date String String Int
 instance Exec Date where
     alias (Date _ a _) = a
     rate  (Date _ _ r) = r
-    start (Date f _ r) cb = do
-      t <- getCurrentTime
-      zone <- getTimeZone t
-      go zone
-     where
-      go zone = doEveryTenthSeconds r $ date zone f >>= cb
+    start (Date f _ r) cb =
+      doEveryTenthSeconds r $ date f >>= cb
 
-date :: TimeZone -> String -> IO String
-date timezone format = do
+date :: String -> IO String
+date format = do
   time <- getCurrentTime
-  let zonedTime = utcToZonedTime timezone time
+  zone <- getTimeZone time
+  let zonedTime = utcToZonedTime zone time
   pure $ formatTime defaultTimeLocale format zonedTime


### PR DESCRIPTION
Check the time zone upon each date execution, so we can accurately reflect daylight savings shifts as they occur.

Before this change, each date execution ran with the same time zone that was current when xmobar started up. I noticed this after my local time zone had shifted from EDT to EST. My xmobar showed 4:30 when the local time was in fact 3:30 (and running `date` on the command line confirmed that my system clock was actually aware of this shift). I had to restart 
xmobar in order to pick up the new time zone.

I repro'd the unexpected behavior by temporarily disabling my system's time syncing, setting the time to 30 seconds before the zone shift, running `date` to confirm I'd set the correct time, restarting xmobar, and observing.
```sh
sudo systemctl stop systemd-timesyncd.service
date --set="01:59:30"
date
```
I observed my xmobar clock go from 1:59 to 2:00, rather than from 1:59 to 1:00 as expected.

I used the same series of steps to confirm that this commit causes the time zone to be dynamically updated.