### PR TITLE
Revert "Optimize date plugin"

### DIFF
--- a/src/Xmobar/Plugins/Date.hs
+++ b/src/Xmobar/Plugins/Date.hs
@@ -31,16 +31,8 @@ data Date = Date String String Int
 
 instance Exec Date where
     alias (Date _ a _) = a
+    run   (Date f _ _) = date f
     rate  (Date _ _ r) = r
-    start (Date f _ r) cb = do
-      t <- getCurrentTime
-      zone <- getTimeZone t
-      go zone
-     where
-      go zone = doEveryTenthSeconds r $ date zone f >>= cb
 
-date :: TimeZone -> String -> IO String
-date timezone format = do
-  time <- getCurrentTime
-  let zonedTime = utcToZonedTime timezone time
-  pure $ formatTime defaultTimeLocale format zonedTime
+date :: String -> IO String
+date format = fmap (formatTime defaultTimeLocale format) getZonedTime


### PR DESCRIPTION
Revert #456 because it prevents time zone changes from being picked up without a restart.

That PR changed the date plugin to avoiding calling `getTimeZone` on each execution, instead calling it just once upon startup and reusing the zone for each subsequent execution. As a result, time zone changes (e.g. daylight savings shifts) are not detected without restarting xmobar.

I noticed this after my local time zone had shifted from EDT to EST. My xmobar showed 4:30 when the local time was in fact 3:30 (and running date on the command line confirmed that my system clock was actually aware of this shift). I had to restart xmobar in order to pick up the new time zone.

I repro'd the unexpected behavior by temporarily disabling my system's time syncing, setting the time to 30 seconds before the zone shift, running date to confirm I'd set the correct time, restarting xmobar, and observing.
```sh
sudo systemctl stop systemd-timesyncd.service
date --set="01:59:30"
date
```
I observed my xmobar clock go from 1:59 to 2:00, rather than from 1:59 to 1:00 as expected.

Following the same steps, I was able to verify that reverting #456 fixes the issue.