### PR TITLE
Fix #499 - Create a SetAlpha Signal and expose it over DBus

### DIFF
--- a/src/Xmobar/App/EventLoop.hs
+++ b/src/Xmobar/App/EventLoop.hs
@@ -176,6 +176,7 @@ eventLoop tv xc@(XConf d r w fs vos is cfg) as signal = do
 
          Hide   t -> hide   (t*100*1000)
          Reveal t -> reveal (t*100*1000)
+         SetAlpha t -> eventLoop tv xc { config = cfg { alpha = t }} as signal
          Toggle t -> toggle t
 
          TogglePersistent -> eventLoop

--- a/src/Xmobar/System/Signal.hs
+++ b/src/Xmobar/System/Signal.hs
@@ -45,6 +45,7 @@ data SignalType = Wakeup
                 | ChangeScreen
                 | Hide   Int
                 | Reveal Int
+                | SetAlpha Int
                 | Toggle Int
                 | TogglePersistent
                 | Action Button Position

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,7 @@ flags:
  xmobar:
    all_extensions: true
    with_threaded: true
+   with_dbus: true
 
 extra-deps:
  - netlink-1.1.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,6 @@ flags:
  xmobar:
    all_extensions: true
    with_threaded: true
-   with_dbus: true
 
 extra-deps:
  - netlink-1.1.1.0


### PR DESCRIPTION
This is subject to the DBus limitation of only one xmobar process "holding the dbus" but with this PR it is possible to send a `SetAlpha x` where x is the Integer value of the desired Alpha (ranging between 0-255 as defined in xmobar config). 