### PR TITLE
Add DateWithTimeZone constructor for computing Date with fixed time zones

### DIFF
--- a/bench/main.hs
+++ b/bench/main.hs
@@ -1,26 +1,51 @@
-{-#LANGUAGE RecordWildCards#-}
+{-# LANGUAGE RecordWildCards #-}
 
-import Gauge
-import Xmobar
-import Xmobar.Plugins.Monitors.Common.Types
-import Xmobar.Plugins.Monitors.Common.Run
-import Xmobar.Plugins.Monitors.Cpu
 import Control.Monad.Reader
 import Data.IORef (newIORef)
+import Data.Time
+import Gauge
+import Xmobar
+import Xmobar.Plugins.Monitors.Common.Run
+import Xmobar.Plugins.Monitors.Common.Types
+import Xmobar.Plugins.Monitors.Cpu
+
+data BenchmarkInput = BenchmarkInput
+  { cpuInput :: CpuArguments,
+    dateInput :: DateInput
+  }
+
+data DateInput = DateInput
+  { diFormat :: String,
+    diZone :: TimeZone
+  }
 
 main :: IO ()
 main = do
   cpuParams <- mkCpuArgs
-  defaultMain $ normalBench cpuParams
-    where
-      normalBench args = [ bgroup "Cpu Benchmarks" $ normalCpuBench args]
+  time <- getCurrentTime
+  zone <- getTimeZone time
+  let benchInput =
+        BenchmarkInput
+          { cpuInput = cpuParams,
+            dateInput =
+              DateInput
+                { diFormat = "D: %B %d %A W%V",
+                  diZone = zone
+                }
+          }
+  defaultMain $ normalBench benchInput
+  where
+    normalBench args =
+      [ -- bgroup "Cpu Benchmarks" $ normalCpuBench (cpuInput args)
+        bgroup "Date Benchmarks" $ dateBench (dateInput args)
+      ]
 
 runMonitor :: MConfig -> Monitor a -> IO a
 runMonitor config r = runReaderT r config
 
 mkCpuArgs :: IO CpuArguments
-mkCpuArgs = getArguments ["-L","3","-H","50","--normal","green","--high","red", "-t", "Cpu: <total>%"]
-  
+mkCpuArgs = getArguments ["-L", "3", "-H", "50", "--normal", "green", "--high", "red", "-t", "Cpu: <total>%"]
+
 -- | The action which will be benchmarked
 cpuAction :: CpuArguments -> IO String
 cpuAction = runCpu
@@ -30,3 +55,15 @@ cpuBenchmark cpuParams = nfIO $ cpuAction cpuParams
 
 normalCpuBench :: CpuArguments -> [Benchmark]
 normalCpuBench args = [bench "CPU normal args" (cpuBenchmark args)]
+
+dateBenchmark :: DateInput -> Benchmarkable
+dateBenchmark params = nfIO $ date (diFormat params)
+
+dateWithTimezoneBenchmark :: DateInput -> Benchmarkable
+dateWithTimezoneBenchmark params = nfIO $ dateWithTimeZone (diZone params) (diFormat params)
+
+dateBench :: DateInput -> [Benchmark]
+dateBench args =
+  [ bench "Date" (dateBenchmark args),
+    bench "DateWithTimeZone" (dateWithTimezoneBenchmark args)
+  ]

--- a/bench/main.hs
+++ b/bench/main.hs
@@ -36,7 +36,7 @@ main = do
   defaultMain $ normalBench benchInput
   where
     normalBench args =
-      [ -- bgroup "Cpu Benchmarks" $ normalCpuBench (cpuInput args)
+      [ bgroup "Cpu Benchmarks" $ normalCpuBench (cpuInput args),
         bgroup "Date Benchmarks" $ dateBench (dateInput args)
       ]
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 _New features_
 
   - New command line option `--add-font` (Ivan Brennan)
+  - Add new `DateWithTimeZone` monitor which is around 45% faster than
+    the Date monitor.
 
 _Bug fixes_
 

--- a/readme.md
+++ b/readme.md
@@ -1548,11 +1548,11 @@ will display "N/A" if for some reason the `date` invocation fails.
 - Accepts same input as the above `Date` monitor.
 - Sample usage: `Run DateWithTimeZone "%a %b %_d %Y <fc=#ee9a00>%H:%M:%S</fc>" "date" 10`
 - The difference with the `Date` monitor is that it's better optimized
-  and 45% faster than the it. It computes the initial time zone
-  information at the start of the xmobar program and reuses it for the
-  subsequent invocations. That means this monitor isn't suited if you
-  are travelling among different time zones, have DST etc unless you
-  are ready to restart xmobar.
+  and 45% faster. It computes the initial time zone information at the
+  start of the xmobar program and reuses it for the subsequent
+  invocations. That means this monitor isn't suited if you are
+  travelling among different time zones, have DST etc unless you are
+  ready to restart xmobar.
 
 ## `DateZone Format Locale Zone Alias RefreshRate`
 

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@
     - [`StdinReader`](#stdinreader)
     - [`UnsafeStdinReader`](#unsafestdinreader)
     - [`Date Format Alias RefreshRate`](#date-format-alias-refreshrate)
+    - [`DateWithTimeZone Format Alias RefreshRate`](#datewithtimezone-format-alias-refreshrate)
     - [`DateZone Format Locale Zone Alias RefreshRate`](#datezone-format-locale-zone-alias-refreshrate)
     - [`CommandReader "/path/to/program" Alias`](#commandreader-pathtoprogram-alias)
     - [`PipeReader "default text:/path/to/pipe" Alias`](#pipereader-default-textpathtopipe-alias)
@@ -1541,6 +1542,17 @@ will display "N/A" if for some reason the `date` invocation fails.
 - Format is a time format string, as accepted by the standard ISO C
   `strftime` function (or Haskell's `formatCalendarTime`).
 - Sample usage: `Run Date "%a %b %_d %Y <fc=#ee9a00>%H:%M:%S</fc>" "date" 10`
+
+## `DateWithTimeZone Format Alias RefreshRate`
+
+- Accepts same input as the above `Date` monitor.
+- Sample usage: `Run DateWithTimeZone "%a %b %_d %Y <fc=#ee9a00>%H:%M:%S</fc>" "date" 10`
+- The difference with the `Date` monitor is that it's better optimized
+  and 45% faster than the it. It computes the initial time zone
+  information at the start of the xmobar program and reuses it for the
+  subsequent invocations. That means this monitor isn't suited if you
+  are travelling among different time zones, have DST etc unless you
+  are ready to restart xmobar.
 
 ## `DateZone Format Locale Zone Alias RefreshRate`
 

--- a/src/Xmobar/Plugins/Date.hs
+++ b/src/Xmobar/Plugins/Date.hs
@@ -40,7 +40,7 @@ instance Exec Date where
                      dateWithTimeZone zone f
     rate  (Date _ _ r) = r
     rate  (DateWithTimeZone _ _ r) = r
-    start (Date f _ r) cb = doEveryTenthSeconds r $ (date f) >>= cb
+    start (Date f _ r) cb = doEveryTenthSeconds r $ date f >>= cb
     start (DateWithTimeZone f _ r) cb = do
       t <- getCurrentTime
       zone <- getTimeZone t

--- a/src/Xmobar/Plugins/Date.hs
+++ b/src/Xmobar/Plugins/Date.hs
@@ -33,11 +33,6 @@ data Date = Date String String Int
 instance Exec Date where
     alias (Date _ a _) = a
     alias (DateWithTimeZone _ a _) = a
-    run   (Date f _ _) = date f
-    run   (DateWithTimeZone f _ _) = do
-                     t <- getCurrentTime
-                     zone <- getTimeZone t
-                     dateWithTimeZone zone f
     rate  (Date _ _ r) = r
     rate  (DateWithTimeZone _ _ r) = r
     start (Date f _ r) cb = doEveryTenthSeconds r $ date f >>= cb

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -357,5 +357,5 @@ benchmark xmobarbench
   hs-source-dirs:
       bench
   ghc-options: -O2
-  build-depends: base, gauge, xmobar, mtl
+  build-depends: base, gauge, xmobar, mtl, time
   default-language: Haskell2010


### PR DESCRIPTION
Also, this time I have added code for benchmarking both of the
components and this is the result in my machine:

```
benchmarked Date Benchmarks/Date
time                 4.434 μs   (4.397 μs .. 4.460 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 4.439 μs   (4.413 μs .. 4.525 μs)
std dev              134.5 ns   (35.90 ns .. 281.0 ns)
variance introduced by outliers: 13% (moderately inflated)

benchmarked Date Benchmarks/DateWithTimeZone
time                 2.266 μs   (2.260 μs .. 2.271 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.258 μs   (2.254 μs .. 2.261 μs)
std dev              13.25 ns   (11.39 ns .. 15.34 ns)
```

And that indicates that `DateWithTimeZone` is around 48% faster than the `Date` monitor.