### PR TITLE
StdinReader: Improve exception handling

### DIFF
--- a/src/Xmobar/Plugins/StdinReader.hs
+++ b/src/Xmobar/Plugins/StdinReader.hs
@@ -27,7 +27,6 @@ import System.IO
 import System.IO.Error (isEOFError)
 import Xmobar.Run.Exec
 import Xmobar.X11.Actions (stripActions)
-import Control.Concurrent (threadDelay)
 import Control.Exception
 import Control.Monad (forever)
 
@@ -45,15 +44,11 @@ instance Exec StdinReader where
       -- there'd be a pileup of xmobars
       handler (fromException -> Just e) | isEOFError e = exitImmediately ExitSuccess
       -- any other exception, like "invalid argument (invalid byte sequence)",
-      -- is logged to both stderr and the bar itself, throttled to avoid
-      -- excessive CPU usage whenever someone pipes garbage into xmobar, and
-      -- then discarded without terminating, so a single charset error doesn't
-      -- break the entire xmobar
+      -- is logged to both stderr and the bar itself
       handler e = do
         let errorMessage = "xmobar: Received exception " <> show e
         hPutStrLn stderr errorMessage
         cb $ stripActions errorMessage
-        threadDelay 1000000
 
 escape :: StdinReader -> String -> String
 escape StdinReader = stripActions

--- a/src/Xmobar/System/Utils.hs
+++ b/src/Xmobar/System/Utils.hs
@@ -20,7 +20,6 @@
 module Xmobar.System.Utils
   ( expandHome
   , changeLoop
-  , onSomeException
   , safeIndex
   ) where
 
@@ -31,7 +30,6 @@ import Data.Maybe (fromMaybe)
 
 import System.Environment
 import System.FilePath
-import Control.Exception
 
 expandHome :: FilePath -> IO FilePath
 expandHome ('~':'/':path) = fmap (</> path) (getEnv "HOME")
@@ -46,15 +44,6 @@ changeLoop s f = atomically s >>= go
             new <- s
             guard (new /= old)
             return new)
-
--- | Like 'finally', but only performs the final action if there was an
--- exception raised by the computation.
---
--- Note that this implementation is a slight modification of
--- onException function.
-onSomeException :: IO a -> (SomeException -> IO b) -> IO a
-onSomeException io what = io `catch` \e -> do _ <- what e
-                                              throwIO (e :: SomeException)
 
 (!!?) :: [a] -> Int -> Maybe a
 (!!?) xs i

--- a/test/Xmobar/Plugins/Monitors/CpuSpec.hs
+++ b/test/Xmobar/Plugins/Monitors/CpuSpec.hs
@@ -23,7 +23,7 @@ spec =
       do let args = ["-L","3","-H","50","--normal","green","--high","red", "-t", "Cpu: <total>% <bar>"]
          cpuArgs <- getArguments args
          cpuValue <- runCpu cpuArgs
-         cpuValue `shouldSatisfy` (\item -> "::" `isSuffixOf` item)
+         cpuValue `shouldSatisfy` (all (`elem` ":#") . last . words)
     it "works with no icon pattern template" $
       do let args = ["-L","3","-H","50","--normal","green","--high","red", "-t", "Cpu: <total>% <bar>", "--", "--load-icon-pattern", "<icon=bright_%%.xpm/>"]
          cpuArgs <- getArguments args

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -335,6 +335,7 @@ test-suite XmobarTest
                  Xmobar.Plugins.Monitors.Common.Output
                  Xmobar.Plugins.Monitors.Common.Files
                  Xmobar.Plugins.Monitors.Cpu
+                 Xmobar.Plugins.Monitors.CpuSpec
                  Xmobar.Plugins.Monitors.Common.Run
                  Xmobar.Run.Exec
                  Xmobar.App.Timer
@@ -347,7 +348,6 @@ test-suite XmobarTest
       other-modules: Xmobar.Plugins.Monitors.Volume
                      Xmobar.Plugins.Monitors.Alsa
                      Xmobar.Plugins.Monitors.AlsaSpec
-                     Xmobar.Plugins.Monitors.CpuSpec
 
       cpp-options: -DALSA
 


### PR DESCRIPTION
This corrects a misleading comment "EOF check is necessary for certain
systems" which was added without complete understanding of the root
cause of #442. That issue was in fact caused by old xmobars not being
terminated on EOF, and is thus necessary on _all_ systems that rely on
EOF to terminate old xmobar before starting a new one.

Furthermore, this fixes another execution path that could lead to xmobar
not being terminated on EOF:

`echo -e '\xff' | xmobar -c '[Run StdinReader]' -t '%StdinReader%'`
would terminate the StdinReader thread upon catching the "invalid
argument (invalid byte sequence)" so there'd be no thread to detect the
subsequent EOF and xmobar would get stuck.

Additionally, I believe that terminating either the thread or the entire
xmobar upon receiving a single miscoded byte isn't desirable, as this
might be an intermittent issue and another input line can be perfectly
okay. Therefore I suggest that the original issue @psibi was trying to
fix by b7a3d6745817 is worked around by introducing a throttling delay
instead of terminating the thread, as I assume that exceptions other
than async and EOF are recoverable.

Fixes: b7a3d6745817 ("Avoid busy looping by not catching all exceptions")
Fixes: 68ac4d3ae6f3 ("Update stderr and the bar on receiving exception")
Fixes: ed0663aac942 ("Add EOF check before getLine operation from stdin")
Fixes: https://github.com/jaor/xmobar/issues/442
Related: https://github.com/jaor/xmobar/pull/439
Related: https://github.com/jaor/xmobar/pull/448