### PR TITLE
Fix two issues related to vertical offsets of additional fonts

### DIFF
--- a/src/Xmobar/App/Main.hs
+++ b/src/Xmobar/App/Main.hs
@@ -63,7 +63,7 @@ xmobar conf = withDeferSignals $ do
       let ic = Map.empty
           to = textOffset conf
           ts = textOffsets conf ++ replicate (length fl) (-1)
-      startLoop (XConf d r w (fs :| fl) (to:ts) ic conf) sig refLock vars
+      startLoop (XConf d r w (fs :| fl) (to :| ts) ic conf) sig refLock vars
 
 configFromArgs :: Config -> IO Config
 configFromArgs cfg = getArgs >>= getOpts >>= doOpts cfg . fst

--- a/src/Xmobar/X11/Draw.hs
+++ b/src/Xmobar/X11/Draw.hs
@@ -131,7 +131,7 @@ printString dpy drw fs@(Xft fonts) _ fc bc x y ay ht s al =
 #endif
 
 -- | An easy way to print the stuff we need to print
-printStrings :: Drawable -> GC -> NE.NonEmpty XFont -> [Int] -> Position
+printStrings :: Drawable -> GC -> NE.NonEmpty XFont -> NE.NonEmpty Int -> Position
              -> Align -> [((Position, Position), Box)] -> [(Widget, TextRenderInfo, Int, Position)] -> X ()
 printStrings _ _ _ _ _ _ _ [] = return ()
 printStrings dr gc fontlist voffs offs a boxes sl@((s,c,i,l):xs) = do
@@ -142,6 +142,7 @@ printStrings dr gc fontlist voffs offs a boxes sl@((s,c,i,l):xs) = do
       totSLen = foldr (\(_,_,_,len) -> (+) len) 0 sl
       remWidth = fi wid - fi totSLen
       fontst = safeIndex fontlist i
+      voff = safeIndex voffs i
       offset = case a of
                  C -> (remWidth + offs) `div` 2
                  R -> remWidth
@@ -149,7 +150,7 @@ printStrings dr gc fontlist voffs offs a boxes sl@((s,c,i,l):xs) = do
       (fc,bc) = case break (==',') (tColorsString c) of
                  (f,',':b) -> (f, b           )
                  (f,    _) -> (f, bgColor conf)
-  valign <- verticalOffset ht s fontst (voffs !! i) conf
+  valign <- verticalOffset ht s fontst voff conf
   let (ht',ay) = case (tBgTopOffset c, tBgBottomOffset c) of
                    (-1,_)  -> (0, -1)
                    (_,-1)  -> (0, -1)

--- a/src/Xmobar/X11/Draw.hs
+++ b/src/Xmobar/X11/Draw.hs
@@ -149,7 +149,7 @@ printStrings dr gc fontlist voffs offs a boxes sl@((s,c,i,l):xs) = do
       (fc,bc) = case break (==',') (tColorsString c) of
                  (f,',':b) -> (f, b           )
                  (f,    _) -> (f, bgColor conf)
-  valign <- verticalOffset ht s (NE.head fontlist) (voffs !! i) conf
+  valign <- verticalOffset ht s fontst (voffs !! i) conf
   let (ht',ay) = case (tBgTopOffset c, tBgBottomOffset c) of
                    (-1,_)  -> (0, -1)
                    (_,-1)  -> (0, -1)

--- a/src/Xmobar/X11/Types.hs
+++ b/src/Xmobar/X11/Types.hs
@@ -35,7 +35,7 @@ data XConf =
           , rect      :: Rectangle
           , window    :: Window
           , fontListS :: NE.NonEmpty XFont
-          , verticalOffsets :: [Int]
+          , verticalOffsets :: NE.NonEmpty Int
           , iconS     :: Map FilePath Bitmap
           , config    :: Config
           }


### PR DESCRIPTION
> Fix crash on <fn=1>x</fn> when no additional fonts are specified

This fixes the following crash that happens with the default xmobar
configuration (using HOME=/ makes xmobar ignore ~/.xmobarrc):

    $ echo "<fn=1>x</fn>" | HOME=/ xmobar
    xmobar: Prelude.!!: index too large

Commit 3e9e1cb9d300 ("Fix crashes/busy looping happening via index") meant
to fix this but apparently it only fixed indexing of fontlist, not voffs,
so the crash was still there.

Fixes: https://github.com/jaor/xmobar/issues/504

---

> Fix vertical centering of additional fonts

The readme says additional fonts are centered vertically if a corresponding
offset isn't specified in `textOffsets`, but this didn't happen as we used
the first font's metrics for centering of all fonts instead.

Fixes: a2365debfaba ("New configuration parameter `textOffsets` (fixes #311)")