### PR TITLE
Subdivide doc/plugins.org

### DIFF
--- a/doc/plugins.org
+++ b/doc/plugins.org
@@ -1264,158 +1264,178 @@ and not new individual messages.
 Listed below are ways to interface xmobar with your window manager of
 choice.
 
-** =XMonadLog=
+** Property-based Logging
+*** =XMonadLog=
 
-- Aliases to XMonadLog
+ - Aliases to XMonadLog
 
-- Displays information from xmonad's =_XMONAD_LOG=. You can use this by
-  using functions from the [[https://hackage.haskell.org/package/xmonad-contrib-0.16/docs/XMonad-Hooks-DynamicLog.html][XMonad.Hooks.DynamicLog]] module. By using the
-  =xmonadPropLog= function in your logHook, you can write the the above
-  property. The following shows a minimal xmonad configuration that
-  spawns xmobar and then writes to the =_XMONAD_LOG= property.
+ - Displays information from xmonad's =_XMONAD_LOG=. You can use this by
+   using functions from the [[https://hackage.haskell.org/package/xmonad-contrib-0.16/docs/XMonad-Hooks-DynamicLog.html][XMonad.Hooks.DynamicLog]] module. By using the
+   =xmonadPropLog= function in your logHook, you can write the the above
+   property. The following shows a minimal xmonad configuration that
+   spawns xmobar and then writes to the =_XMONAD_LOG= property.
 
-  #+begin_src haskell
-    main = do
-      spawn "xmobar"
-      xmonad $ def
-        { logHook = dynamicLogString defaultPP >>= xmonadPropLog
-        }
-  #+end_src
+   #+begin_src haskell
+     main = do
+       spawn "xmobar"
+       xmonad $ def
+         { logHook = dynamicLogString defaultPP >>= xmonadPropLog
+         }
+   #+end_src
 
-  This plugin can be used as a sometimes more convenient alternative to
-  =StdinReader=. For instance, it allows you to (re)start xmobar outside
-  xmonad.
+   This plugin can be used as a sometimes more convenient alternative to
+   =StdinReader=. For instance, it allows you to (re)start xmobar outside
+   xmonad.
 
-** =UnsafeXMonadLog=
+*** =UnsafeXMonadLog=
 
-- Aliases to UnsafeXMonadLog
-- Displays any text received by xmobar on the =_XMONAD_LOG= atom.
-- Will not do anything to the text received. This means you can pass
-  xmobar dynamic actions. Be careful to escape (using =<raw=…>=) or
-  remove tags from dynamic text that you pipe through to xmobar in this
-  way.
+ - Aliases to UnsafeXMonadLog
+ - Displays any text received by xmobar on the =_XMONAD_LOG= atom.
+ - Will not do anything to the text received. This means you can pass
+   xmobar dynamic actions. Be careful to escape (using =<raw=…>=) or
+   remove tags from dynamic text that you pipe through to xmobar in this
+   way.
 
-- Sample usage: Send the list of your workspaces, enclosed by actions
-  tags, to xmobar.  This enables you to switch to a workspace when you
-  click on it in xmobar!
+ - Sample usage: Send the list of your workspaces, enclosed by actions
+   tags, to xmobar.  This enables you to switch to a workspace when you
+   click on it in xmobar!
 
-  #+begin_src shell
-    <action=`xdotool key alt+1`>ws1</action> <action=`xdotool key alt+1`>ws2</action>
-  #+end_src
+   #+begin_src shell
+     <action=`xdotool key alt+1`>ws1</action> <action=`xdotool key alt+1`>ws2</action>
+   #+end_src
 
-- If you use xmonad, It is advised that you still use =xmobarStrip= for
-  the =ppTitle= in your logHook:
+ - If you use xmonad, It is advised that you still use =xmobarStrip= for
+   the =ppTitle= in your logHook:
 
-  #+begin_src haskell
-    myPP = defaultPP { ppTitle = xmobarStrip }
-    main = xmonad $ def
-      { logHook = dynamicLogString myPP >>= xmonadPropLog
-      }
-  #+end_src
+   #+begin_src haskell
+     myPP = defaultPP { ppTitle = xmobarStrip }
+     main = xmonad $ def
+       { logHook = dynamicLogString myPP >>= xmonadPropLog
+       }
+   #+end_src
 
-** =StdinReader=
+*** =XPropertyLog PropName=
 
-- Aliases to StdinReader
-- Displays any text received by xmobar on its standard input.
-- Strips actions from the text received. This means you can't pass
-  dynamic actions via stdin. This is safer than =UnsafeStdinReader=
-  because there is no need to escape the content before passing it to
-  xmobar's standard input.
+ - Aliases to =PropName=
+ - Reads the X property named by =PropName= (a string) and displays its
+   value. The [[https://github.com/jaor/xmobar/raw/master/examples/xmonadpropwrite.hs][examples/xmonadpropwrite.hs script]] in xmobar's distribution
+   can be used to set the given property from the output of any other
+   program or script.
 
-** =UnsafeStdinReader=
+*** =UnsafeXPropertyLog PropName=
 
-- Aliases to UnsafeStdinReader
-- Displays any text received by xmobar on its standard input.
-- Similar to [[=UnsafeXMonadLog=][UnsafeXMonadLog]], in the sense that it does not strip any
-  actions from the received text, only using =stdin= and not a property
-  atom of the root window. Please be equally carefully when using this
-  as when using =UnsafeXMonadLog=!
+ - Aliases to =PropName=
+ - Same as =XPropertyLog= but the input is not filtered to avoid
+   injection of actions (cf. =UnsafeXMonadLog=). The program writing the
+   value of the read property is responsible of performing any needed
+   cleanups.
 
+*** =NamedXPropertyLog PropName Alias=
 
+ - Aliases to =Alias=
+ - Same as =XPropertyLog= but a custom alias can be specified.
 
+*** =UnsafeNamedXPropertyLog PropName Alias=
 
+ - Aliases to =Alias=
+ - Same as =UnsafeXPropertyLog=, but a custom alias can be specified.
 
+** Logging via Stdin
+*** =StdinReader=
 
+ - Aliases to StdinReader
+ - Displays any text received by xmobar on its standard input.
+ - Strips actions from the text received. This means you can't pass
+   dynamic actions via stdin. This is safer than =UnsafeStdinReader=
+   because there is no need to escape the content before passing it to
+   xmobar's standard input.
 
-** =CommandReader "/path/to/program" Alias=
+*** =UnsafeStdinReader=
 
-- Runs the given program, and displays its standard output.
+ - Aliases to UnsafeStdinReader
+ - Displays any text received by xmobar on its standard input.
+ - Similar to [[=UnsafeXMonadLog=][UnsafeXMonadLog]], in the sense that it does not strip any
+   actions from the received text, only using =stdin= and not a property
+   atom of the root window. Please be equally carefully when using this
+   as when using =UnsafeXMonadLog=!
 
-** =PipeReader "default text:/path/to/pipe" Alias=
+** Pipe-based Logging
+*** =PipeReader "default text:/path/to/pipe" Alias=
 
-- Reads its displayed output from the given pipe.
-- Prefix an optional default text separated by a colon
-- Expands environment variables in the first argument of syntax =${VAR}=
-  or =$VAR=
+ - Reads its displayed output from the given pipe.
+ - Prefix an optional default text separated by a colon
+ - Expands environment variables in the first argument of syntax =${VAR}=
+   or =$VAR=
 
-** =MarqueePipeReader "default text:/path/to/pipe" (length, rate, sep) Alias=
+*** =MarqueePipeReader "default text:/path/to/pipe" (length, rate, sep) Alias=
 
-- Generally equivalent to PipeReader
+ - Generally equivalent to PipeReader
 
-- Text is displayed as marquee with the specified length, rate in 10th
-  seconds and separator when it wraps around
+ - Text is displayed as marquee with the specified length, rate in 10th
+   seconds and separator when it wraps around
 
-  #+begin_src haskell
-    Run MarqueePipeReader "/tmp/testpipe" (10, 7, "+") "mpipe"
-  #+end_src
+   #+begin_src haskell
+     Run MarqueePipeReader "/tmp/testpipe" (10, 7, "+") "mpipe"
+   #+end_src
 
-- Expands environment variables in the first argument
+ - Expands environment variables in the first argument
 
-** =BufferedPipeReader Alias [(Timeout, Bool, "/path/to/pipe1"), ..]=
+*** =BufferedPipeReader Alias [(Timeout, Bool, "/path/to/pipe1"), ..]=
 
-- Display data from multiple pipes.
+ - Display data from multiple pipes.
 
-- Timeout (in tenth of seconds) is the value after which the previous
-  content is restored i.e. if there was already something from a
-  previous pipe it will be put on display again, overwriting the current
-  status.
+ - Timeout (in tenth of seconds) is the value after which the previous
+   content is restored i.e. if there was already something from a
+   previous pipe it will be put on display again, overwriting the current
+   status.
 
-- A pipe with Timeout of 0 will be displayed permanently, just like
-  =PipeReader=
+ - A pipe with Timeout of 0 will be displayed permanently, just like
+   =PipeReader=
 
-- The boolean option indicates whether new data for this pipe should
-  make xmobar appear (unhide, reveal). In this case, the Timeout
-  additionally specifies when the window should be hidden again. The
-  output is restored in any case.
+ - The boolean option indicates whether new data for this pipe should
+   make xmobar appear (unhide, reveal). In this case, the Timeout
+   additionally specifies when the window should be hidden again. The
+   output is restored in any case.
 
-- Use it for OSD-like status bars e.g. for setting the volume or
-  brightness:
+ - Use it for OSD-like status bars e.g. for setting the volume or
+   brightness:
 
-  #+begin_src haskell
-    Run BufferedPipeReader "bpr"
-        [ (  0, False, "/tmp/xmobar_window"  )
-        , ( 15,  True, "/tmp/xmobar_status"  )
-        ]
-  #+end_src
+   #+begin_src haskell
+     Run BufferedPipeReader "bpr"
+         [ (  0, False, "/tmp/xmobar_window"  )
+         , ( 15,  True, "/tmp/xmobar_status"  )
+         ]
+   #+end_src
 
-  Have your window manager send window titles to =/tmp/xmobar_window=.
-  They will always be shown and not reveal your xmobar. Sending some
-  status information to =/tmp/xmobar_status= will reveal xmonad for 1.5
-  seconds and temporarily overwrite the window titles.
+   Have your window manager send window titles to =/tmp/xmobar_window=.
+   They will always be shown and not reveal your xmobar. Sending some
+   status information to =/tmp/xmobar_status= will reveal xmonad for 1.5
+   seconds and temporarily overwrite the window titles.
 
-- Take a look at [[http://github.com/jaor/xmobar/raw/master/examples/status.sh][examples/status.sh]]
+ - Take a look at [[http://github.com/jaor/xmobar/raw/master/examples/status.sh][examples/status.sh]]
 
-- Expands environment variables for the pipe path
+ - Expands environment variables for the pipe path
 
-** =HandleReader Handle Alias=
+** Handle-based Logging
+*** =HandleReader Handle Alias=
 
-- Display data from a Haskell =Handle=
+ - Display data from a Haskell =Handle=
 
-- This plugin is only useful if you are running xmobar from another
-  Haskell program like XMonad.
+ - This plugin is only useful if you are running xmobar from another
+   Haskell program like XMonad.
 
-- You can use =System.Process.createPipe= to create a pair of =read= &
-  =write= Handles. Pass the =read= Handle to HandleReader and write your
-  output to the =write= Handle:
+ - You can use =System.Process.createPipe= to create a pair of =read= &
+   =write= Handles. Pass the =read= Handle to HandleReader and write your
+   output to the =write= Handle:
 
-  #+begin_src haskell
-    (readHandle, writeHandle) <- createPipe
-    xmobarProcess <- forkProcess $ xmobar myConfig
-            { commands =
-                Run (HandleReader readHandle "handle") : commands myConfig
-            }
-    hPutStr writeHandle "Hello World"
-  #+end_src
+   #+begin_src haskell
+     (readHandle, writeHandle) <- createPipe
+     xmobarProcess <- forkProcess $ xmobar myConfig
+             { commands =
+                 Run (HandleReader readHandle "handle") : commands myConfig
+             }
+     hPutStr writeHandle "Hello World"
+   #+end_src
 
 * Executing External Commands
 

--- a/doc/plugins.org
+++ b/doc/plugins.org
@@ -1,5 +1,3 @@
-#+OPTIONS: toc:t
-
 * System Monitor Plugins
 
 This is the description of the system monitor plugins available in
@@ -33,7 +31,7 @@ then specifies the battery-specific =off= option.
     100
 #+end_src
 
-** Icon patterns
+** Icon Patterns
 
 Some monitors allow usage of strings that depend on some integer value
 from 0 to 8 by replacing all occurrences of =%%= with it
@@ -228,1036 +226,1016 @@ something like:
   Glasgow Airport: 16.0C
 #+end_src
 
-** =Uptime Args RefreshRate=
-
-- Aliases to =uptime=
-- Args: default monitor arguments. The low and high thresholds refer to
-  the number of days.
-- Variables that can be used with the =-t/--template= argument: =days=,
-  =hours=, =minutes=, =seconds=. The total uptime is the sum of all
-  those fields. You can set the =-S= argument to =True= to add units to
-  the display of those numeric fields.
-- Default template: =Up: <days>d <hours>h <minutes>m=
-
-** =Weather StationID Args RefreshRate=
-
-- Aliases to the Station ID: so =Weather "LIPB" []= can be used in
-  template as =%LIPB%=
-- Thresholds refer to temperature in the selected units
-- Args: default monitor arguments, plus:
-
-  - =--weathers= /string/ : display a default string when the =weather=
-    variable is not reported.
-
-    - short option: =-w=
-    - Default: ""
-
-  - =--useManager= /bool/ : Whether to use one single manager per
-    monitor for managing network connections or create a new one every
-    time a connection is made.
-
-    - Short option: =-m=
-    - Default: True
-
-- Variables that can be used with the =-t/--template= argument:
-  =station=, =stationState=, =year=, =month=, =day=, =hour=,
-  =windCardinal=, =windAzimuth=, =windMph=, =windKnots=, =windMs=,
-  =windKmh= =visibility=, =skyCondition=, =weather=, =tempC=, =tempF=,
-  =dewPointC=, =dewPointF=, =rh=, =pressure=
-- Default template: =<station>: <tempC>C, rh <rh>% (<hour>)=
-- Retrieves weather information from http://tgftp.nws.noaa.gov. Here is
-  an [[https://tgftp.nws.noaa.gov/data/observations/metar/decoded/CYLD.TXT][example]], also showcasing the kind of information that may be
-  extracted.
-
-** =WeatherX StationID SkyConditions Args RefreshRate=
-
-- Works in the same way as =Weather=, but takes an additional argument,
-  a list of pairs from sky conditions to their replacement (typically a
-  unicode string or an icon specification).
-- Use the variable =skyConditionS= to display the replacement of the
-  corresponding sky condition. All other =Weather= template variables
-  are available as well.
-
-For example:
-
-#+begin_src haskell
-  WeatherX "LEBL"
-           [ ("clear", "🌣")
-           , ("sunny", "🌣")
-           , ("mostly clear", "🌤")
-           , ("mostly sunny", "🌤")
-           , ("partly sunny", "⛅")
-           , ("fair", "🌑")
-           , ("cloudy","☁")
-           , ("overcast","☁")
-           , ("partly cloudy", "⛅")
-           , ("mostly cloudy", "🌧")
-           , ("considerable cloudiness", "⛈")]
-           ["-t", "<fn=2><skyConditionS></fn> <tempC>° <rh>%  <windKmh> (<hour>)"
-           , "-L","10", "-H", "25", "--normal", "black"
-           , "--high", "lightgoldenrod4", "--low", "darkseagreen4"]
-           18000
-#+end_src
-
-As mentioned, the replacement string can also be an icon specification,
-such as =("clear", "<icon=weather-clear.xbm/>")=.
-
-** =Network Interface Args RefreshRate=
-
-- Aliases to the interface name: so =Network "eth0" []= can be used as
-  =%eth0%=
-- Thresholds refer to velocities expressed in Kb/s
-- Args: default monitor arguments, plus:
-
-  - =--rx-icon-pattern=: dynamic string for reception rate in =rxipat=.
-  - =--tx-icon-pattern=: dynamic string for transmission rate in
-    =txipat=.
-  - =--up=: string used for the =up= variable value when the interface
-    is up.
-
-- Variables that can be used with the =-t=/=--template= argument: =dev=,
-  =rx=, =tx=, =rxbar=, =rxvbar=, =rxipat=, =txbar=, =txvbar=, =txipat=,
-  =up=. Reception and transmission rates (=rx= and =tx=) are displayed
-  by default as Kb/s, without any suffixes, but you can set the =-S= to
-  "True" to make them displayed with adaptive units (Kb/s, Mb/s, etc.).
-- Default template: =<dev>: <rx>KB|<tx>KB=
-
-** =DynNetwork Args RefreshRate=
-
-- Active interface is detected automatically
-- Aliases to "dynnetwork"
-- Thresholds are expressed in Kb/s
-- Args: default monitor arguments, plus:
-
-- =--rx-icon-pattern=: dynamic string for reception rate in =rxipat=.
-- =--tx-icon-pattern=: dynamic string for transmission rate in =txipat=
-- =--devices=: comma-separated list of devices to show.
-
-- Variables that can be used with the =-t=/=--template= argument:
-  =dev=, =rx=, =tx=, =rxbar=, =rxvbar=, =rxipat=, =txbar=, =txvbar=,
-  =txipat=.
-
-Reception and transmission rates (=rx= and =tx=) are displayed in Kbytes
-per second, and you can set the =-S= to "True" to make them displayed
-with units (the string "Kb/s").
-- Default template: =<dev>: <rx>KB|<tx>KB=
-- Example of usage of =--devices= option:
-
-    =["--", "--devices", "wlp2s0,enp0s20f41"]=
-
-** =Wireless Interface Args RefreshRate=
-
-- If set to "", first suitable wireless interface is used.
-- Aliases to the interface name with the suffix "wi": thus,
-  =Wireless   "wlan0" []= can be used as =%wlan0wi%=, and
-  =Wireless "" []= as =%wi%=.
-- Args: default monitor arguments, plus:
-
-  - =--quality-icon-pattern=: dynamic string for connection quality in
-    =qualityipat=.
-
-- Variables that can be used with the =-t=/=--template= argument:
-  =ssid=, =signal=, =quality=, =qualitybar=, =qualityvbar=,
-  =qualityipat=
-- Thresholds refer to link quality on a =[0, 100]= scale. Note that
-  =quality= is calculated from =signal= (in dBm) by a possibly lossy
-  conversion. It is also not taking into account many factors such as
-  noise level, air busy time, transcievers' capabilities and the others
-  which can have drastic impact on the link performance.
-- Default template: =<ssid> <quality>=
-- To activate this plugin you must pass the =with_nl80211= or the
-  =with_iwlib= flag during compilation.
-
-** =Memory Args RefreshRate=
-
-- Aliases to =memory=
-- Args: default monitor arguments, plus:
-
-  - =--used-icon-pattern=: dynamic string for used memory ratio in
-    =usedipat=.
-  - =--free-icon-pattern=: dynamic string for free memory ratio in
-    =freeipat=.
-  - =--available-icon-pattern=: dynamic string for available memory
-    ratio in =availableipat=.
-
-- Thresholds refer to percentage of used memory
-- Variables that can be used with the =-t/--template= argument:
-  =total=, =free=, =buffer=, =cache=, =available=, =used=, =usedratio=,
-  =usedbar=, =usedvbar=, =usedipat=, =freeratio=, =freebar=, =freevbar=,
-  =freeipat=, =availableratio=, =availablebar=, =availablevbar=,
-  =availableipat=
-- Default template: =Mem: <usedratio>% (<cache>M)=
-
-** =Swap Args RefreshRate=
-
-- Aliases to =swap=
-- Args: default monitor arguments
-- Thresholds refer to percentage of used swap
-- Variables that can be used with the =-t/--template= argument:
-  =total=, =used=, =free=, =usedratio=
-- Default template: =Swap: <usedratio>%=
-
-** =Cpu Args RefreshRate=
-
-- Aliases to =cpu=
-- Args: default monitor arguments, plus:
-
-  - =--load-icon-pattern=: dynamic string for cpu load in =ipat=
-
-- Thresholds refer to percentage of CPU load
-- Variables that can be used with the =-t/--template= argument:
-  =total=, =bar=, =vbar=, =ipat=, =user=, =nice=, =system=, =idle=,
-  =iowait=
-- Default template: =Cpu: <total>%=
-
-** =MultiCpu Args RefreshRate=
-
-- Aliases to =multicpu=
-- Args: default monitor arguments, plus:
-
-  - =--load-icon-pattern=: dynamic string for overall cpu load in
-    =ipat=.
-  - =--load-icon-patterns=: dynamic string for each cpu load in
-    =autoipat=, =ipat{i}=. This option can be specified several times.
-    nth option corresponds to nth cpu.
-  - =--fallback-icon-pattern=: dynamic string used by =autoipat= and
-    =ipat{i}= when no =--load-icon-patterns= has been provided for
-    =cpu{i}=
-  - =--contiguous-icons=: flag (no value needs to be provided) that
-    causes the load icons to be drawn without padding.
-
-- Thresholds refer to percentage of CPU load
-- Variables that can be used with the =-t/--template= argument:
-  =autototal=, =autobar=, =autovbar=, =autoipat=, =autouser=,
-  =autonice=, =autosystem=, =autoidle=, =total=, =bar=, =vbar=, =ipat=,
-  =user=, =nice=, =system=, =idle=, =total0=, =bar0=, =vbar0=, =ipat0=,
-  =user0=, =nice0=, =system0=, =idle0=, ... The auto* variables
-  automatically detect the number of CPUs on the system and display one
-  entry for each.
-- Default template: =Cpu: <total>%=
-
-** =Battery Args RefreshRate=
-
-- Same as
-
-  #+begin_src haskell
-    BatteryP ["BAT", "BAT0", "BAT1", "BAT2"] Args RefreshRate
-  #+end_src
-
-** =BatteryP Dirs Args RefreshRate=
-
-- Aliases to =battery=
-
-- Dirs: list of directories in =/sys/class/power_supply/= where to look
-  for the ACPI files of each battery. Example: =["BAT0","BAT1","BAT2"]=.
-  Only up to 3 existing directories will be searched.
-
-- Args: default monitor arguments, plus the following specific ones
-  (these options, being specific to the monitor, are to be specified
-  after a =--= in the argument list):
-
-  - =-O=: string for AC "on" status (default: "On")
-  - =-i=: string for AC "idle" status (default: "On")
-  - =-o=: string for AC "off" status (default: "Off")
-  - =-L=: low power (=watts=) threshold (default: 10)
-  - =-H=: high power threshold (default: 12)
-  - =-l=: color to display power lower than the =-L= threshold
-  - =-m=: color to display power lower than the =-H= threshold
-  - =-h=: color to display power higher than the =-H= threshold
-  - =-p=: color to display positive power (battery charging)
-  - =-f=: file in =/sys/class/power_supply= with AC info (default:
-    "AC/online")
-  - =-A=: a number between 0 and 100, threshold below which the action
-    given by =-a=, if any, is performed (default: 5)
-  - =-a=: a string with a system command that is run when the percentage
-    left in the battery is less or equal than the threshold given by the
-    =-A= option. If not present, no action is undertaken.
-  - =-P=: to include a percentage symbol in =left=.
-  - =--on-icon-pattern=: dynamic string for current battery charge when
-    AC is "on" in =leftipat=.
-  - =--off-icon-pattern=: dynamic string for current battery charge when
-    AC is "off" in =leftipat=.
-  - =--idle-icon-pattern=: dynamic string for current battery charge
-    when AC is "idle" in =leftipat=.
-  - =--lows=: string for AC "off" status and power lower than the =-L=
-    threshold (default: "")
-  - =--mediums=: string for AC "off" status and power lower than the
-    =-H= threshold (default: "")
-  - =--highs=: string for AC "off" status and power higher than the =-H=
-    threshold (default: "")
-
-- Variables that can be used with the =-t/--template= argument:
-  =left=, =leftbar=, =leftvbar=, =leftipat=, =timeleft=, =watts=,
-  =acstatus=
-
-- Default template: =Batt: <watts>, <left>% / <timeleft>=
-
-- Example (note that you need "--" to separate regular monitor options
-  from Battery's specific ones):
-
-  #+begin_src haskell
-    Run BatteryP ["BAT0"]
-                 ["-t", "<acstatus><watts> (<left>%)",
-                  "-L", "10", "-H", "80", "-p", "3",
-                  "--", "-O", "<fc=green>On</fc> - ", "-i", "",
-                  "-L", "-15", "-H", "-5",
-                  "-l", "red", "-m", "blue", "-h", "green"
-                  "-a", "notify-send -u critical 'Battery running out!!'",
-                  "-A", "3"]
-                 600
-  #+end_src
-
-  In the above example, the thresholds before the =--= separator affect
-  only the =<left>= and =<leftbar>= fields, while those after the
-  separator affect how =<watts>= is displayed. For this monitor, neither
-  the generic nor the specific options have any effect on =<timeleft>=.
-  We are also telling the monitor to execute the unix command
-  =notify-send= when the percentage left in the battery reaches 6%.
-
-  It is also possible to specify template variables in the =-O= and =-o=
-  switches, as in the following example:
-
-  #+begin_src haskell
-    Run BatteryP ["BAT0"]
-                 ["-t", "<acstatus>"
-                 , "-L", "10", "-H", "80"
-                 , "-l", "red", "-h", "green"
-                 , "--", "-O", "Charging", "-o", "Battery: <left>%"
-                 ] 10
-  #+end_src
-
-- The "idle" AC state is selected whenever the AC power entering the
-  battery is zero.
-
-** =BatteryN Dirs Args RefreshRate Alias=
-
-Works like =BatteryP=, but lets you specify an alias for the monitor
-other than "battery". Useful in case you one separate monitors for more
-than one battery.
-
-** =TopProc Args RefreshRate=
-
-- Aliases to =top=
-- Args: default monitor arguments. The low and high thresholds (=-L= and
-  =-H=) denote, for memory entries, the percent of the process memory
-  over the total amount of memory currently in use and, for cpu entries,
-  the activity percentage (i.e., the value of =cpuN=, which takes values
-  between 0 and 100).
-- Variables that can be used with the =-t/--template= argument: =no=,
-  =name1=, =cpu1=, =both1=, =mname1=, =mem1=, =mboth1=, =name2=, =cpu2=,
-  =both2=, =mname2=, =mem2=, =mboth2=, ...
-- Default template: =<both1>=
-- Displays the name and cpu/mem usage of running processes (=bothn= and
-  =mboth= display both, and is useful to specify an overall maximum
-  and/or minimum width, using the =-m/-M= arguments. =no= gives the
-  total number of processes.
-
-** =TopMem Args RefreshRate=
-
-- Aliases to =topmem=
-- Args: default monitor arguments. The low and high thresholds (=-L= and
-  =-H=) denote the percent of the process memory over the total amount
-  of memory currently in use.
-- Variables that can be used with the =-t/--template= argument:
-  =name1=, =mem1=, =both1=, =name2=, =mem2=, =both2=, ...
-- Default template: =<both1>=
-- Displays the name and RSS (resident memory size) of running processes
-  (=bothn= displays both, and is useful to specify an overall maximum
-  and/or minimum width, using the =-m/-M= arguments.
-
-** =Date Format Alias RefreshRate=
-
-- Format is a time format string, as accepted by the standard ISO C
-  =strftime= function (or Haskell's =formatCalendarTime=).  Basically,
-  if =date +"my-string"= works with your command then =Date= will handle
-  it correctly.
-
-- Timezone changes are picked up automatically every minute.
-
-- Sample usage:
-
-  #+begin_src haskell
-    Run Date "%a %b %_d %Y <fc=#ee9a00>%H:%M:%S</fc>" "date" 10
-  #+end_src
-
-** =DateZone Format Locale Zone Alias RefreshRate=
-
-A variant of the =Date= monitor where one is able to explicitly set the
-time-zone, as well as the locale.
-
-- The format of =DateZone= is exactly the same as =Date=.
-
-- If =Locale= is =""= (the empty string) the default locale of the
-  system is used, otherwise use the given locale. If there are more
-  instances of =DateZone=, using the empty string as input for =Locale=
-  is not recommended.
-
-- =Zone= is the name of the =TimeZone=. It is assumed that the time-zone
-  database is stored in =/usr/share/zoneinfo/=. If the empty string is
-  given as =Zone=, the default system time is used.
-
-- Sample usage:
-
-  #+begin_src haskell
-    Run DateZone "%a %H:%M:%S" "de_DE.UTF-8" "Europe/Vienna" "viennaTime" 10
-  #+end_src
-
-** =DiskU Disks Args RefreshRate=
-
-- Aliases to =disku=
-
-- Disks: list of pairs of the form (device or mount point, template),
-  where the template can contain =<size>=, =<free>=, =<used>=, =<freep>=
-  or =<usedp>=, =<freebar>=, =<freevbar>=, =<freeipat>=, =<usedbar>=,
-  =<usedvbar>= or =<usedipat>= for total, free, used, free percentage
-  and used percentage of the given file system capacity.
-
-- Thresholds refer to usage percentage.
-
-- Args: default monitor arguments. =-t/--template= is ignored. Plus
-
-  - =--free-icon-pattern=: dynamic string for free disk space in
-    =freeipat=.
-  - =--used-icon-pattern=: dynamic string for used disk space in
-    =usedipat=.
-
-- Default template: none (you must specify a template for each file
-  system).
-
-- Example:
-
-  #+begin_src haskell
-    DiskU [("/", "<used>/<size>"), ("sdb1", "<usedbar>")]
-          ["-L", "20", "-H", "50", "-m", "1", "-p", "3"]
-          20
-  #+end_src
+** Battery Monitors
+*** =Battery Args RefreshRate=
+
+ Same as
+
+ #+begin_src haskell
+   BatteryP ["BAT", "BAT0", "BAT1", "BAT2"] Args RefreshRate
+ #+end_src
+
+*** =BatteryP Dirs Args RefreshRate=
+
+ - Aliases to =battery=
+
+ - Dirs: list of directories in =/sys/class/power_supply/= where to look
+   for the ACPI files of each battery. Example: =["BAT0","BAT1","BAT2"]=.
+   Only up to 3 existing directories will be searched.
+
+ - Args: default monitor arguments, plus the following specific ones
+   (these options, being specific to the monitor, are to be specified
+   after a =--= in the argument list):
+
+   - =-O=: string for AC "on" status (default: "On")
+   - =-i=: string for AC "idle" status (default: "On")
+   - =-o=: string for AC "off" status (default: "Off")
+   - =-L=: low power (=watts=) threshold (default: 10)
+   - =-H=: high power threshold (default: 12)
+   - =-l=: color to display power lower than the =-L= threshold
+   - =-m=: color to display power lower than the =-H= threshold
+   - =-h=: color to display power higher than the =-H= threshold
+   - =-p=: color to display positive power (battery charging)
+   - =-f=: file in =/sys/class/power_supply= with AC info (default:
+     "AC/online")
+   - =-A=: a number between 0 and 100, threshold below which the action
+     given by =-a=, if any, is performed (default: 5)
+   - =-a=: a string with a system command that is run when the percentage
+     left in the battery is less or equal than the threshold given by the
+     =-A= option. If not present, no action is undertaken.
+   - =-P=: to include a percentage symbol in =left=.
+   - =--on-icon-pattern=: dynamic string for current battery charge when
+     AC is "on" in =leftipat=.
+   - =--off-icon-pattern=: dynamic string for current battery charge when
+     AC is "off" in =leftipat=.
+   - =--idle-icon-pattern=: dynamic string for current battery charge
+     when AC is "idle" in =leftipat=.
+   - =--lows=: string for AC "off" status and power lower than the =-L=
+     threshold (default: "")
+   - =--mediums=: string for AC "off" status and power lower than the
+     =-H= threshold (default: "")
+   - =--highs=: string for AC "off" status and power higher than the =-H=
+     threshold (default: "")
+
+ - Variables that can be used with the =-t/--template= argument:
+   =left=, =leftbar=, =leftvbar=, =leftipat=, =timeleft=, =watts=,
+   =acstatus=
+
+ - Default template: =Batt: <watts>, <left>% / <timeleft>=
+
+ - Example (note that you need "--" to separate regular monitor options
+   from Battery's specific ones):
+
+   #+begin_src haskell
+     Run BatteryP ["BAT0"]
+                  ["-t", "<acstatus><watts> (<left>%)",
+                   "-L", "10", "-H", "80", "-p", "3",
+                   "--", "-O", "<fc=green>On</fc> - ", "-i", "",
+                   "-L", "-15", "-H", "-5",
+                   "-l", "red", "-m", "blue", "-h", "green"
+                   "-a", "notify-send -u critical 'Battery running out!!'",
+                   "-A", "3"]
+                  600
+   #+end_src
+
+   In the above example, the thresholds before the =--= separator affect
+   only the =<left>= and =<leftbar>= fields, while those after the
+   separator affect how =<watts>= is displayed. For this monitor, neither
+   the generic nor the specific options have any effect on =<timeleft>=.
+   We are also telling the monitor to execute the unix command
+   =notify-send= when the percentage left in the battery reaches 6%.
+
+   It is also possible to specify template variables in the =-O= and =-o=
+   switches, as in the following example:
+
+   #+begin_src haskell
+     Run BatteryP ["BAT0"]
+                  ["-t", "<acstatus>"
+                  , "-L", "10", "-H", "80"
+                  , "-l", "red", "-h", "green"
+                  , "--", "-O", "Charging", "-o", "Battery: <left>%"
+                  ] 10
+   #+end_src
+
+ - The "idle" AC state is selected whenever the AC power entering the
+   battery is zero.
+
+*** =BatteryN Dirs Args RefreshRate Alias=
+
+ Works like =BatteryP=, but lets you specify an alias for the monitor
+ other than "battery". Useful in case you one separate monitors for more
+ than one battery.
+** Cpu and Memory Monitors
+*** =Cpu Args RefreshRate=
 
-** =DiskIO Disks Args RefreshRate=
+ - Aliases to =cpu=
+ - Args: default monitor arguments, plus:
 
-- Aliases to =diskio=
+   - =--load-icon-pattern=: dynamic string for cpu load in =ipat=
 
-- Disks: list of pairs of the form (device or mount point, template),
-  where the template can contain =<total>=, =<read>=, =<write>= for
-  total, read and write speed, respectively, as well as =<totalb>=,
-  =<readb>=, =<writeb>=, which report number of bytes during the last
-  refresh period rather than speed. There are also bar versions of each:
-  =<totalbar>=, =<totalvbar>=, =<totalipat>=, =<readbar>=, =<readvbar>=,
-  =<readipat>=, =<writebar>=, =<writevbar>=, and =<writeipat>=; and
-  their "bytes" counterparts: =<totalbbar>=, =<totalbvbar>=,
-  =<totalbipat>=, =<readbbar>=, =<readbvbar>=, =<readbipat>=,
-  =<writebbar>=, =<writebvbar>=, and =<writebipat>=.
+ - Thresholds refer to percentage of CPU load
+ - Variables that can be used with the =-t/--template= argument:
+   =total=, =bar=, =vbar=, =ipat=, =user=, =nice=, =system=, =idle=,
+   =iowait=
+ - Default template: =Cpu: <total>%=
 
-- Thresholds refer to speed in b/s
+*** =MultiCpu Args RefreshRate=
 
-- Args: default monitor arguments. =-t/--template= is ignored. Plus
+ - Aliases to =multicpu=
+ - Args: default monitor arguments, plus:
 
-  - =--total-icon-pattern=: dynamic string for total disk I/O in
-    =<totalipat>=.
-  - =--write-icon-pattern=: dynamic string for write disk I/O in
-    =<writeipat>=.
-  - =--read-icon-pattern=: dynamic string for read disk I/O in
-    =<readipat>=.
+   - =--load-icon-pattern=: dynamic string for overall cpu load in
+     =ipat=.
+   - =--load-icon-patterns=: dynamic string for each cpu load in
+     =autoipat=, =ipat{i}=. This option can be specified several times.
+     nth option corresponds to nth cpu.
+   - =--fallback-icon-pattern=: dynamic string used by =autoipat= and
+     =ipat{i}= when no =--load-icon-patterns= has been provided for
+     =cpu{i}=
+   - =--contiguous-icons=: flag (no value needs to be provided) that
+     causes the load icons to be drawn without padding.
 
-- Default template: none (you must specify a template for each file
-  system).
+ - Thresholds refer to percentage of CPU load
+ - Variables that can be used with the =-t/--template= argument:
+   =autototal=, =autobar=, =autovbar=, =autoipat=, =autouser=,
+   =autonice=, =autosystem=, =autoidle=, =total=, =bar=, =vbar=, =ipat=,
+   =user=, =nice=, =system=, =idle=, =total0=, =bar0=, =vbar0=, =ipat0=,
+   =user0=, =nice0=, =system0=, =idle0=, ... The auto* variables
+   automatically detect the number of CPUs on the system and display one
+   entry for each.
+ - Default template: =Cpu: <total>%=
 
-- Example:
+*** =CpuFreq Args RefreshRate=
 
-  #+begin_src haskell
-    DiskIO [("/", "<read> <write>"), ("sdb1", "<total>")] [] 10
-  #+end_src
+ - Aliases to =cpufreq=
 
-** =ThermalZone Number Args RefreshRate=
+ - Args: default monitor arguments
 
-- Aliases to "thermaln": so =ThermalZone 0 []= can be used in template
-  as =%thermal0%=
+ - Thresholds refer to frequency in GHz
 
-- Thresholds refer to temperature in degrees
+ - Variables that can be used with the =-t/--template= argument:
+   =cpu0=, =cpu1=, .., =cpuN=
 
-- Args: default monitor arguments
+ - Default template: =Freq: <cpu0>GHz=
 
-- Variables that can be used with the =-t/--template= argument: =temp=
+ - This monitor requires acpi_cpufreq module to be loaded in kernel
 
-- Default template: =<temp>C=
+ - Example:
 
-- This plugin works only on systems with devices having thermal zone.
-  Check directories in =/sys/class/thermal= for possible values of the
-  zone number (e.g., 0 corresponds to =thermal_zone0= in that
-  directory).
+   #+begin_src haskell
+     Run CpuFreq ["-t", "Freq:<cpu0>|<cpu1>GHz", "-L", "0", "-H", "2",
+                  "-l", "lightblue", "-n","white", "-h", "red"] 50
+   #+end_src
 
-- Example:
+*** =CoreTemp Args RefreshRate=
 
-  #+begin_src haskell
-    Run ThermalZone 0 ["-t","<id>: <temp>C"] 30
-  #+end_src
+ - Aliases to =coretemp=
 
-** =Thermal Zone Args RefreshRate=
+ - Args: default monitor arguments
 
-- *This plugin is deprecated. Use =ThermalZone= instead.*
+ - Thresholds refer to temperature in degrees
 
-- Aliases to the Zone: so =Thermal "THRM" []= can be used in template as
-  =%THRM%=
+ - Variables that can be used with the =-t/--template= argument:
+   =core0=, =core1=, .., =coreN=
 
-- Args: default monitor arguments
+ - Default template: =Temp: <core0>C=
 
-- Thresholds refer to temperature in degrees
+ - This monitor requires coretemp module to be loaded in kernel
 
-- Variables that can be used with the =-t/--template= argument: =temp=
+ - Example:
 
-- Default template: =Thm: <temp>C=
+   #+begin_src haskell
+     Run CoreTemp ["-t", "Temp:<core0>|<core1>C",
+                   "-L", "40", "-H", "60",
+                   "-l", "lightblue", "-n", "gray90", "-h", "red"] 50
+   #+end_src
 
-- This plugin works only on systems with devices having thermal zone.
-  Check directories in /proc/acpi/thermal_zone for possible values.
+*** =MultiCoreTemp Args RefreshRate=
 
-- Example:
+ - Aliases to =multicoretemp=
 
-  #+begin_src haskell
-    Run Thermal "THRM" ["-t","iwl4965-temp: <temp>C"] 50
-  #+end_src
+ - Args: default monitor arguments, plus:
 
-** =CpuFreq Args RefreshRate=
+   - =--max-icon-pattern=: dynamic string for overall cpu load in
+     =maxipat=.
+   - =--avg-icon-pattern=: dynamic string for overall cpu load in
+     =avgipat=.
+   - =--mintemp=: temperature in degree Celsius, that sets the lower
+     limit for percentage calculation.
+   - =--maxtemp=: temperature in degree Celsius, that sets the upper
+     limit for percentage calculation.
+   - =--hwmonitor-path=: this monitor tries to find coretemp devices by
+     looking for them in directories following the pattern
+     =/sys/bus/platform/devices/coretemp.*/hwmon/hwmon*=, but some
+     processors (notably Ryzen) might expose those files in a different
+     tree (e.g., Ryzen) puts them somewhere in "/sys/class/hwmon/hwmon*",
+     and the lookup is most costly. With this option, it is possible to
+     explicitly specify the full path to the directory where the
+     =tempN_label= and =tempN_input= files are located.
 
-- Aliases to =cpufreq=
+ - Thresholds refer to temperature in degree Celsius
 
-- Args: default monitor arguments
+ - Variables that can be used with the =-t/--template= argument: =max=,
+   =maxpc=, =maxbar=, =maxvbar=, =maxipat=, =avg=, =avgpc=, =avgbar=,
+   =avgvbar=, =avgipat=, =core0=, =core1=, ..., =coreN=
 
-- Thresholds refer to frequency in GHz
+   The /pc, /bar, /vbar and /ipat variables are showing percentages on
+   the scale defined by =--mintemp= and =--maxtemp=. The max* and avg*
+   variables to the highest and the average core temperature.
 
-- Variables that can be used with the =-t/--template= argument:
-  =cpu0=, =cpu1=, .., =cpuN=
+ - Default template: =Temp: <max>°C - <maxpc>%=
 
-- Default template: =Freq: <cpu0>GHz=
+ - This monitor requires coretemp module to be loaded in kernel
 
-- This monitor requires acpi_cpufreq module to be loaded in kernel
+ - Example:
 
-- Example:
+   #+begin_src haskell
+     Run MultiCoreTemp ["-t", "Temp: <avg>°C | <avgpc>%",
+                        "-L", "60", "-H", "80",
+                        "-l", "green", "-n", "yellow", "-h", "red",
+                        "--", "--mintemp", "20", "--maxtemp", "100"] 50
+   #+end_src
+*** =Memory Args RefreshRate=
 
-  #+begin_src haskell
-    Run CpuFreq ["-t", "Freq:<cpu0>|<cpu1>GHz", "-L", "0", "-H", "2",
-                 "-l", "lightblue", "-n","white", "-h", "red"] 50
-  #+end_src
+ - Aliases to =memory=
+ - Args: default monitor arguments, plus:
 
-** =CoreTemp Args RefreshRate=
+   - =--used-icon-pattern=: dynamic string for used memory ratio in
+     =usedipat=.
+   - =--free-icon-pattern=: dynamic string for free memory ratio in
+     =freeipat=.
+   - =--available-icon-pattern=: dynamic string for available memory
+     ratio in =availableipat=.
 
-- Aliases to =coretemp=
+ - Thresholds refer to percentage of used memory
+ - Variables that can be used with the =-t/--template= argument:
+   =total=, =free=, =buffer=, =cache=, =available=, =used=, =usedratio=,
+   =usedbar=, =usedvbar=, =usedipat=, =freeratio=, =freebar=, =freevbar=,
+   =freeipat=, =availableratio=, =availablebar=, =availablevbar=,
+   =availableipat=
+ - Default template: =Mem: <usedratio>% (<cache>M)=
 
-- Args: default monitor arguments
+*** =Swap Args RefreshRate=
 
-- Thresholds refer to temperature in degrees
+ - Aliases to =swap=
+ - Args: default monitor arguments
+ - Thresholds refer to percentage of used swap
+ - Variables that can be used with the =-t/--template= argument:
+   =total=, =used=, =free=, =usedratio=
+ - Default template: =Swap: <usedratio>%=
+** Date Monitors
+*** =Date Format Alias RefreshRate=
 
-- Variables that can be used with the =-t/--template= argument:
-  =core0=, =core1=, .., =coreN=
+ - Format is a time format string, as accepted by the standard ISO C
+   =strftime= function (or Haskell's =formatCalendarTime=).  Basically,
+   if =date +"my-string"= works with your command then =Date= will handle
+   it correctly.
 
-- Default template: =Temp: <core0>C=
+ - Timezone changes are picked up automatically every minute.
 
-- This monitor requires coretemp module to be loaded in kernel
+ - Sample usage:
 
-- Example:
+   #+begin_src haskell
+     Run Date "%a %b %_d %Y <fc=#ee9a00>%H:%M:%S</fc>" "date" 10
+   #+end_src
 
-  #+begin_src haskell
-    Run CoreTemp ["-t", "Temp:<core0>|<core1>C",
-                  "-L", "40", "-H", "60",
-                  "-l", "lightblue", "-n", "gray90", "-h", "red"] 50
-  #+end_src
+*** =DateZone Format Locale Zone Alias RefreshRate=
 
-** =MultiCoreTemp Args RefreshRate=
+ A variant of the =Date= monitor where one is able to explicitly set the
+ time-zone, as well as the locale.
 
-- Aliases to =multicoretemp=
+ - The format of =DateZone= is exactly the same as =Date=.
 
-- Args: default monitor arguments, plus:
+ - If =Locale= is =""= (the empty string) the default locale of the
+   system is used, otherwise use the given locale. If there are more
+   instances of =DateZone=, using the empty string as input for =Locale=
+   is not recommended.
 
-  - =--max-icon-pattern=: dynamic string for overall cpu load in
-    =maxipat=.
-  - =--avg-icon-pattern=: dynamic string for overall cpu load in
-    =avgipat=.
-  - =--mintemp=: temperature in degree Celsius, that sets the lower
-    limit for percentage calculation.
-  - =--maxtemp=: temperature in degree Celsius, that sets the upper
-    limit for percentage calculation.
-  - =--hwmonitor-path=: this monitor tries to find coretemp devices by
-    looking for them in directories following the pattern
-    =/sys/bus/platform/devices/coretemp.*/hwmon/hwmon*=, but some
-    processors (notably Ryzen) might expose those files in a different
-    tree (e.g., Ryzen) puts them somewhere in "/sys/class/hwmon/hwmon*",
-    and the lookup is most costly. With this option, it is possible to
-    explicitly specify the full path to the directory where the
-    =tempN_label= and =tempN_input= files are located.
+ - =Zone= is the name of the =TimeZone=. It is assumed that the time-zone
+   database is stored in =/usr/share/zoneinfo/=. If the empty string is
+   given as =Zone=, the default system time is used.
 
-- Thresholds refer to temperature in degree Celsius
+ - Sample usage:
 
-- Variables that can be used with the =-t/--template= argument: =max=,
-  =maxpc=, =maxbar=, =maxvbar=, =maxipat=, =avg=, =avgpc=, =avgbar=,
-  =avgvbar=, =avgipat=, =core0=, =core1=, ..., =coreN=
+   #+begin_src haskell
+     Run DateZone "%a %H:%M:%S" "de_DE.UTF-8" "Europe/Vienna" "viennaTime" 10
+   #+end_src
+** Disk Monitors
+*** =DiskU Disks Args RefreshRate=
 
-  The /pc, /bar, /vbar and /ipat variables are showing percentages on
-  the scale defined by =--mintemp= and =--maxtemp=. The max* and avg*
-  variables to the highest and the average core temperature.
+ - Aliases to =disku=
 
-- Default template: =Temp: <max>°C - <maxpc>%=
+ - Disks: list of pairs of the form (device or mount point, template),
+   where the template can contain =<size>=, =<free>=, =<used>=, =<freep>=
+   or =<usedp>=, =<freebar>=, =<freevbar>=, =<freeipat>=, =<usedbar>=,
+   =<usedvbar>= or =<usedipat>= for total, free, used, free percentage
+   and used percentage of the given file system capacity.
 
-- This monitor requires coretemp module to be loaded in kernel
+ - Thresholds refer to usage percentage.
 
-- Example:
+ - Args: default monitor arguments. =-t/--template= is ignored. Plus
 
-  #+begin_src haskell
-    Run MultiCoreTemp ["-t", "Temp: <avg>°C | <avgpc>%",
-                       "-L", "60", "-H", "80",
-                       "-l", "green", "-n", "yellow", "-h", "red",
-                       "--", "--mintemp", "20", "--maxtemp", "100"] 50
-  #+end_src
+   - =--free-icon-pattern=: dynamic string for free disk space in
+     =freeipat=.
+   - =--used-icon-pattern=: dynamic string for used disk space in
+     =usedipat=.
 
-** =Volume Mixer Element Args RefreshRate=
+ - Default template: none (you must specify a template for each file
+   system).
 
-- Aliases to the mixer name and element name separated by a colon. Thus,
-  =Volume "default" "Master" [] 10= can be used as =%default:Master%=.
-- Args: default monitor arguments. Also accepts:
+ - Example:
 
-  - =-O= /string/ On string
+   #+begin_src haskell
+     DiskU [("/", "<used>/<size>"), ("sdb1", "<usedbar>")]
+           ["-L", "20", "-H", "50", "-m", "1", "-p", "3"]
+           20
+   #+end_src
 
-    - The string used in place of =<status>= when the mixer element is
-      on. Defaults to "[on]".
-    - Long option: =--on=
+*** =DiskIO Disks Args RefreshRate=
 
-  - =-o= /string/ Off string
+ - Aliases to =diskio=
 
-    - The string used in place of =<status>= when the mixer element is
-      off. Defaults to "[off]".
-    - Long option: =--off=
+ - Disks: list of pairs of the form (device or mount point, template),
+   where the template can contain =<total>=, =<read>=, =<write>= for
+   total, read and write speed, respectively, as well as =<totalb>=,
+   =<readb>=, =<writeb>=, which report number of bytes during the last
+   refresh period rather than speed. There are also bar versions of each:
+   =<totalbar>=, =<totalvbar>=, =<totalipat>=, =<readbar>=, =<readvbar>=,
+   =<readipat>=, =<writebar>=, =<writevbar>=, and =<writeipat>=; and
+   their "bytes" counterparts: =<totalbbar>=, =<totalbvbar>=,
+   =<totalbipat>=, =<readbbar>=, =<readbvbar>=, =<readbipat>=,
+   =<writebbar>=, =<writebvbar>=, and =<writebipat>=.
 
-  - =-C= /color/ On color
+ - Thresholds refer to speed in b/s
 
-    - The color to be used for =<status>= when the mixer element is on.
-      Defaults to "green".
-    - Long option: =--onc=
+ - Args: default monitor arguments. =-t/--template= is ignored. Plus
 
-  - =-c= /color/ Off color
+   - =--total-icon-pattern=: dynamic string for total disk I/O in
+     =<totalipat>=.
+   - =--write-icon-pattern=: dynamic string for write disk I/O in
+     =<writeipat>=.
+   - =--read-icon-pattern=: dynamic string for read disk I/O in
+     =<readipat>=.
 
-    - The color to be used for =<status>= when the mixer element is off.
-      Defaults to "red".
-    - Long option: =--offc=
+ - Default template: none (you must specify a template for each file
+   system).
 
-  - =--highd= /number/ High threshold for dB. Defaults to -5.0.
-  - =--lowd= /number/ Low threshold for dB. Defaults to -30.0.
-  - =--volume-icon-pattern= /string/ dynamic string for current volume
-    in =volumeipat=.
-  - =-H= /number/ High threshold for volume (in %). Defaults to 60.0.
+ - Example:
 
-    - Long option: =--highv=
+   #+begin_src haskell
+     DiskIO [("/", "<read> <write>"), ("sdb1", "<total>")] [] 10
+   #+end_src
 
-  - =-L= /number/ Low threshold for volume (in %). Defaults to 20.0.
+** Keyboard Monitors
+*** =Kbd Opts=
 
-    - Long option: =--lowv=
+ - Registers to XKB/X11-Events and output the currently active keyboard
+   layout. Supports replacement of layout names.
 
-  - =-h=: /string/ High string
+ - Aliases to =kbd=
 
-    - The string added in front of =<status>= when the mixer element is
-      on and the volume percentage is higher than the =-H= threshold.
-      Defaults to "".
-    - Long option: =--highs=
+ - Opts is a list of tuples:
 
-  - =-m=: /string/ Medium string
+   - first element of the tuple is the search string
+   - second element of the tuple is the corresponding replacement
 
-    - The string added in front of =<status>= when the mixer element is
-      on and the volume percentage is lower than the =-H= threshold.
-      Defaults to "".
-    - Long option: =--mediums=
+ - Example:
 
-  - =-l=: /string/ Low string
+   #+begin_src haskell
+     Run Kbd [("us(dvorak)", "DV"), ("us", "US")]
+   #+end_src
 
-    - The string added in front of =<status>= when the mixer element is
-      on and the volume percentage is lower than the =-L= threshold.
-      Defaults to "".
-    - Long option: =--lows=
+*** =Locks=
 
-- Variables that can be used with the =-t/--template= argument:
-  =volume=, =volumebar=, =volumevbar=, =volumeipat=, =dB=, =status=,
-  =volumestatus=
-- Note that =dB= might only return 0 on your system. This is known to
-  happen on systems with a pulseaudio backend.
-- Default template: =Vol: <volume>% <status>=
-- Requires the package [[http://hackage.haskell.org/package/alsa-core][alsa-core]] and [[http://hackage.haskell.org/package/alsa-mixer][alsa-mixer]] installed in your
-  system. In addition, to activate this plugin you must pass the
-  =with_alsa= flag during compilation.
+ - Displays the status of Caps Lock, Num Lock and Scroll Lock.
 
-** =Alsa Mixer Element Args=
+ - Aliases to =locks=
 
-Like [[=Volume Mixer Element Args RefreshRate=][Volume]] but with the following differences:
+ - Example:
 
-- Uses event-based refreshing via =alsactl monitor= instead of polling,
-  so it will refresh instantly when there's a volume change, and won't
-  use CPU until a change happens.
-- Aliases to =alsa:= followed by the mixer name and element name
-  separated by a colon. Thus, =Alsa "default" "Master" []= can be used
-  as =%alsa:default:Master%=.
-- Additional options (after the =--=):
-  - =--alsactl=/path/to/alsactl=: If this option is not specified,
-    =alsactl= will be sought in your =PATH= first, and failing that, at
-    =/usr/sbin/alsactl= (this is its location on Debian systems.
-    =alsactl monitor= works as a non-root user despite living in
-    =/usr/sbin=.).
-  - =stdbuf= (from coreutils) must be (and most probably already is) in
-    your =PATH=.
+   #+begin_src haskell
+     Run Locks
+   #+end_src
+** Process Monitors
+*** =TopProc Args RefreshRate=
 
-** =MPD Args RefreshRate=
+ - Aliases to =top=
+ - Args: default monitor arguments. The low and high thresholds (=-L= and
+   =-H=) denote, for memory entries, the percent of the process memory
+   over the total amount of memory currently in use and, for cpu entries,
+   the activity percentage (i.e., the value of =cpuN=, which takes values
+   between 0 and 100).
+ - Variables that can be used with the =-t/--template= argument: =no=,
+   =name1=, =cpu1=, =both1=, =mname1=, =mem1=, =mboth1=, =name2=, =cpu2=,
+   =both2=, =mname2=, =mem2=, =mboth2=, ...
+ - Default template: =<both1>=
+ - Displays the name and cpu/mem usage of running processes (=bothn= and
+   =mboth= display both, and is useful to specify an overall maximum
+   and/or minimum width, using the =-m/-M= arguments. =no= gives the
+   total number of processes.
 
-- This monitor will only be compiled if you ask for it using the
-  =with_mpd= flag. It needs [[http://hackage.haskell.org/package/libmpd/][libmpd]] 5.0 or later (available on Hackage).
+*** =TopMem Args RefreshRate=
 
-- Aliases to =mpd=
+ - Aliases to =topmem=
+ - Args: default monitor arguments. The low and high thresholds (=-L= and
+   =-H=) denote the percent of the process memory over the total amount
+   of memory currently in use.
+ - Variables that can be used with the =-t/--template= argument:
+   =name1=, =mem1=, =both1=, =name2=, =mem2=, =both2=, ...
+ - Default template: =<both1>=
+ - Displays the name and RSS (resident memory size) of running processes
+   (=bothn= displays both, and is useful to specify an overall maximum
+   and/or minimum width, using the =-m/-M= arguments.
+** Thermal Monitors
+*** =ThermalZone Number Args RefreshRate=
 
-- Args: default monitor arguments. In addition you can provide =-P=,
-  =-S= and =-Z=, with an string argument, to represent the playing,
-  stopped and paused states in the =statei= template field. The
-  environment variables =MPD_HOST= and =MPD_PORT= are used to configure
-  the mpd server to communicate with, unless given in the additional
-  arguments =-p= (=--port=) and =-h= (=--host=). Also available:
+ - Aliases to "thermaln": so =ThermalZone 0 []= can be used in template
+   as =%thermal0%=
 
-  - =lapsed-icon-pattern=: dynamic string for current track position in
-    =ipat=.
+ - Thresholds refer to temperature in degrees
 
-- Variables that can be used with the =-t/--template= argument: =bar=,
-  =vbar=, =ipat=, =state=, =statei=, =volume=, =length=, =lapsed=,
-  =remaining=, =plength= (playlist length), =ppos= (playlist position),
-  =flags= (ncmpcpp-style playback mode), =name=, =artist=, =composer=,
-  =performer=, =album=, =title=, =track=, =file=, =genre=, =date=
+ - Args: default monitor arguments
 
-- Default template: =MPD: <state>=
+ - Variables that can be used with the =-t/--template= argument: =temp=
 
-- Example (note that you need "--" to separate regular monitor options
-  from MPD's specific ones):
+ - Default template: =<temp>C=
 
-  #+begin_src haskell
-    Run MPD ["-t",
-             "<composer> <title> (<album>) <track>/<plength> <statei> [<flags>]",
-             "--", "-P", ">>", "-Z", "|", "-S", "><"] 10
-  #+end_src
+ - This plugin works only on systems with devices having thermal zone.
+   Check directories in =/sys/class/thermal= for possible values of the
+   zone number (e.g., 0 corresponds to =thermal_zone0= in that
+   directory).
 
-** =MPDX Args RefreshRate Alias=
+ - Example:
 
-Like =MPD= but uses as alias its last argument instead of "mpd".
+   #+begin_src haskell
+     Run ThermalZone 0 ["-t","<id>: <temp>C"] 30
+   #+end_src
 
-** =Mpris1 PlayerName Args RefreshRate=
+*** =Thermal Zone Args RefreshRate=
 
-- Aliases to =mpris1=
+ - *This plugin is deprecated. Use =ThermalZone= instead.*
 
-- Requires [[http://hackage.haskell.org/package/dbus][dbus]] and [[http://hackage.haskell.org/package/text][text]] packages. To activate, pass the =with_mpris=
-  flag during compilation.
+ - Aliases to the Zone: so =Thermal "THRM" []= can be used in template as
+   =%THRM%=
 
-- PlayerName: player supporting MPRIS v1 protocol. Some players need
-  this to be an all lowercase name (e.g. "spotify"), but some others
-  don't.
+ - Args: default monitor arguments
 
-- Args: default monitor arguments.
+ - Thresholds refer to temperature in degrees
 
-- Variables that can be used with the =-t/--template= argument:
-  =album=, =artist=, =arturl=, =length=, =title=, =tracknumber=
+ - Variables that can be used with the =-t/--template= argument: =temp=
 
-- Default template: =<artist> - <title>=
+ - Default template: =Thm: <temp>C=
 
-- Example:
+ - This plugin works only on systems with devices having thermal zone.
+   Check directories in /proc/acpi/thermal_zone for possible values.
 
-  #+begin_src haskell
-    Run Mpris1 "clementine" ["-t", "<artist> - [<tracknumber>] <title>"] 10
-  #+end_src
+ - Example:
 
-** =Mpris2 PlayerName Args RefreshRate=
+   #+begin_src haskell
+     Run Thermal "THRM" ["-t","iwl4965-temp: <temp>C"] 50
+   #+end_src
+** Volume Monitors
+*** =Volume Mixer Element Args RefreshRate=
 
-- Aliases to =mpris2=
+ - Aliases to the mixer name and element name separated by a colon. Thus,
+   =Volume "default" "Master" [] 10= can be used as =%default:Master%=.
+ - Args: default monitor arguments. Also accepts:
 
-- Requires [[http://hackage.haskell.org/package/dbus][dbus]] and [[http://hackage.haskell.org/package/text][text]] packages. To activate, pass the =with_mpris=
-  flag during compilation.
+   - =-O= /string/ On string
 
-- PlayerName: player supporting MPRIS v2 protocol. Some players need
-  this to be an all lowercase name (e.g. "spotify"), but some others
-  don't.
+     - The string used in place of =<status>= when the mixer element is
+       on. Defaults to "[on]".
+     - Long option: =--on=
 
-- Args: default monitor arguments.
+   - =-o= /string/ Off string
 
-- Variables that can be used with the =-t/--template= argument:
-  =album=, =artist=, =arturl=, =length=, =title=, =tracknumber=,
-  =composer=, =genre=
+     - The string used in place of =<status>= when the mixer element is
+       off. Defaults to "[off]".
+     - Long option: =--off=
 
-- Default template: =<artist> - <title>=
+   - =-C= /color/ On color
 
-- Example:
+     - The color to be used for =<status>= when the mixer element is on.
+       Defaults to "green".
+     - Long option: =--onc=
 
-  #+begin_src haskell
-    Run Mpris2 "spotify" ["-t", "<artist> - [<composer>] <title>"] 10
-  #+end_src
+   - =-c= /color/ Off color
 
-** =Mail Args Alias=
+     - The color to be used for =<status>= when the mixer element is off.
+       Defaults to "red".
+     - Long option: =--offc=
 
-- Args: list of maildirs in form =[("name1","path1"),...]=. Paths may
-  start with a '~' to expand to the user's home directory.
+   - =--highd= /number/ High threshold for dB. Defaults to -5.0.
+   - =--lowd= /number/ Low threshold for dB. Defaults to -30.0.
+   - =--volume-icon-pattern= /string/ dynamic string for current volume
+     in =volumeipat=.
+   - =-H= /number/ High threshold for volume (in %). Defaults to 60.0.
 
-- This plugin requires inotify support in your Linux kernel and the
-  [[http://hackage.haskell.org/package/hinotify/][hinotify]] package. To activate, pass the =with_inotify= flag during
-  compilation.
+     - Long option: =--highv=
 
-- Example:
+   - =-L= /number/ Low threshold for volume (in %). Defaults to 20.0.
 
-  #+begin_src haskell
-    Run Mail [("inbox", "~/var/mail/inbox"),
-              ("lists", "~/var/mail/lists")]
-             "mail"
-  #+end_src
+     - Long option: =--lowv=
 
-** =MailX Args Opts Alias=
+   - =-h=: /string/ High string
 
-- Args: list of maildirs in form =[("name1","path1","color1"),...]=.
-  Paths may start with a '~' to expand to the user's home directory.
-  When mails are present, counts are displayed with the given name and
-  color.
+     - The string added in front of =<status>= when the mixer element is
+       on and the volume percentage is higher than the =-H= threshold.
+       Defaults to "".
+     - Long option: =--highs=
 
-- Opts is a possibly empty list of options, as flags. Possible values:
-  -d dir --dir dir a string giving the base directory where maildir
-  files with a relative path live. -p prefix --prefix prefix a string
-  giving a prefix for the list of displayed mail counts -s suffix
-  --suffix suffix a string giving a suffix for the list of displayed
-  mail counts
+   - =-m=: /string/ Medium string
 
-- This plugin requires inotify support in your Linux kernel and the
-  [[http://hackage.haskell.org/package/hinotify/][hinotify]] package. To activate, pass the =with_inotify= flag during
-  compilation.
+     - The string added in front of =<status>= when the mixer element is
+       on and the volume percentage is lower than the =-H= threshold.
+       Defaults to "".
+     - Long option: =--mediums=
 
-- Example:
+   - =-l=: /string/ Low string
 
-  #+begin_src haskell
-    Run MailX [("I", "inbox", "green"),
-               ("L", "lists", "orange")]
-              ["-d", "~/var/mail", "-p", " ", "-s", " "]
+     - The string added in front of =<status>= when the mixer element is
+       on and the volume percentage is lower than the =-L= threshold.
+       Defaults to "".
+     - Long option: =--lows=
+
+ - Variables that can be used with the =-t/--template= argument:
+   =volume=, =volumebar=, =volumevbar=, =volumeipat=, =dB=, =status=,
+   =volumestatus=
+ - Note that =dB= might only return 0 on your system. This is known to
+   happen on systems with a pulseaudio backend.
+ - Default template: =Vol: <volume>% <status>=
+ - Requires the package [[http://hackage.haskell.org/package/alsa-core][alsa-core]] and [[http://hackage.haskell.org/package/alsa-mixer][alsa-mixer]] installed in your
+   system. In addition, to activate this plugin you must pass the
+   =with_alsa= flag during compilation.
+
+*** =Alsa Mixer Element Args=
+
+ Like [[=Volume Mixer Element Args RefreshRate=][Volume]] but with the following differences:
+
+ - Uses event-based refreshing via =alsactl monitor= instead of polling,
+   so it will refresh instantly when there's a volume change, and won't
+   use CPU until a change happens.
+ - Aliases to =alsa:= followed by the mixer name and element name
+   separated by a colon. Thus, =Alsa "default" "Master" []= can be used
+   as =%alsa:default:Master%=.
+ - Additional options (after the =--=):
+   - =--alsactl=/path/to/alsactl=: If this option is not specified,
+     =alsactl= will be sought in your =PATH= first, and failing that, at
+     =/usr/sbin/alsactl= (this is its location on Debian systems.
+     =alsactl monitor= works as a non-root user despite living in
+     =/usr/sbin=.).
+   - =stdbuf= (from coreutils) must be (and most probably already is) in
+     your =PATH=.
+** Mail Monitors
+*** =Mail Args Alias=
+
+ - Args: list of maildirs in form =[("name1","path1"),...]=. Paths may
+   start with a '~' to expand to the user's home directory.
+
+ - This plugin requires inotify support in your Linux kernel and the
+   [[http://hackage.haskell.org/package/hinotify/][hinotify]] package. To activate, pass the =with_inotify= flag during
+   compilation.
+
+ - Example:
+
+   #+begin_src haskell
+     Run Mail [("inbox", "~/var/mail/inbox"),
+               ("lists", "~/var/mail/lists")]
               "mail"
-  #+end_src
-
-** =MBox Mboxes Opts Alias=
-
-- Mboxes a list of mbox files of the form =[("name", "path", "color")]=,
-  where name is the displayed name, path the absolute or relative (to
-  BaseDir) path of the mbox file, and color the color to use to display
-  the mail count (use an empty string for the default).
-
-- Opts is a possibly empty list of options, as flags. Possible values:
-  -a --all (no arg) Show all mailboxes, even if empty. -u (no arg) Show
-  only the mailboxes' names, sans counts. -d dir --dir dir a string
-  giving the base directory where mbox files with a relative path live.
-  -p prefix --prefix prefix a string giving a prefix for the list of
-  displayed mail counts -s suffix --suffix suffix a string giving a
-  suffix for the list of displayed mail counts
-
-- Paths may start with a '~' to expand to the user's home directory.
-
-- This plugin requires inotify support in your Linux kernel and the
-  [[http://hackage.haskell.org/package/hinotify/][hinotify]] package. To activate, pass the =with_inotify= flag during
-  compilation.
-
-- Example. The following command look for mails in =/var/mail/inbox= and
-  =~/foo/mbox=, and will put a space in front of the printed string
-  (when it's not empty); it can be used in the template with the alias
-  =mbox=:
-
-  #+begin_src haskell
-    Run MBox [("I ", "inbox", "red"), ("O ", "~/foo/mbox", "")]
-             ["-d", "/var/mail/", "-p", " "] "mbox"
-  #+end_src
-
-** =NotmuchMail Alias Args Rate=
-
-This plugin checks for new mail, provided that this mail is indexed by
-=notmuch=. In the =notmuch= spirit, this plugin checks for new *threads*
-and not new individual messages.
+   #+end_src
+
+*** =MailX Args Opts Alias=
+
+ - Args: list of maildirs in form =[("name1","path1","color1"),...]=.
+   Paths may start with a '~' to expand to the user's home directory.
+   When mails are present, counts are displayed with the given name and
+   color.
+
+ - Opts is a possibly empty list of options, as flags. Possible values:
+   -d dir --dir dir a string giving the base directory where maildir
+   files with a relative path live. -p prefix --prefix prefix a string
+   giving a prefix for the list of displayed mail counts -s suffix
+   --suffix suffix a string giving a suffix for the list of displayed
+   mail counts
+
+ - This plugin requires inotify support in your Linux kernel and the
+   [[http://hackage.haskell.org/package/hinotify/][hinotify]] package. To activate, pass the =with_inotify= flag during
+   compilation.
+
+ - Example:
+
+   #+begin_src haskell
+     Run MailX [("I", "inbox", "green"),
+                ("L", "lists", "orange")]
+               ["-d", "~/var/mail", "-p", " ", "-s", " "]
+               "mail"
+   #+end_src
+
+*** =MBox Mboxes Opts Alias=
+
+ - Mboxes a list of mbox files of the form =[("name", "path", "color")]=,
+   where name is the displayed name, path the absolute or relative (to
+   BaseDir) path of the mbox file, and color the color to use to display
+   the mail count (use an empty string for the default).
+
+ - Opts is a possibly empty list of options, as flags. Possible values:
+   -a --all (no arg) Show all mailboxes, even if empty. -u (no arg) Show
+   only the mailboxes' names, sans counts. -d dir --dir dir a string
+   giving the base directory where mbox files with a relative path live.
+   -p prefix --prefix prefix a string giving a prefix for the list of
+   displayed mail counts -s suffix --suffix suffix a string giving a
+   suffix for the list of displayed mail counts
+
+ - Paths may start with a '~' to expand to the user's home directory.
+
+ - This plugin requires inotify support in your Linux kernel and the
+   [[http://hackage.haskell.org/package/hinotify/][hinotify]] package. To activate, pass the =with_inotify= flag during
+   compilation.
+
+ - Example. The following command look for mails in =/var/mail/inbox= and
+   =~/foo/mbox=, and will put a space in front of the printed string
+   (when it's not empty); it can be used in the template with the alias
+   =mbox=:
+
+   #+begin_src haskell
+     Run MBox [("I ", "inbox", "red"), ("O ", "~/foo/mbox", "")]
+              ["-d", "/var/mail/", "-p", " "] "mbox"
+   #+end_src
+
+*** =NotmuchMail Alias Args Rate=
+
+ This plugin checks for new mail, provided that this mail is indexed by
+ =notmuch=. In the =notmuch= spirit, this plugin checks for new *threads*
+ and not new individual messages.
+
+ - Alias: What name the plugin should have in your template string.
+
+ - Args: A list of =MailItem= s of the form
+
+   #+begin_src haskell
+     [ MailItem "name" "address" "query"
+     ...
+     ]
+   #+end_src
+
+   or, using explicit record syntax:
+
+   #+begin_src haskell
+     [ MailItem
+         { name    = "name"
+         , address = "address"
+         , query   = "query"
+         }
+       ...
+     ]
+   #+end_src
 
-- Alias: What name the plugin should have in your template string.
+   where
 
-- Args: A list of =MailItem= s of the form
+   - =name= is what gets printed in the status bar before the number of
+     new threads.
+   - =address= is the e-mail address of the recipient, i.e. we only query
+     mail that was send to this particular address (in more concrete
+     terms, we pass the address to the =to:= constructor when performing
+     the search). If =address= is empty, we search through all unread
+     mail, regardless of whom it was sent to.
+   - =query= is funneled to =notmuch search= verbatim. For the general
+     query syntax, consult =notmuch search --help=, as well as
+     =notmuch-search-terms(7)=. Note that the =unread= tag is *always*
+     added in front of the query and composed with it via an *and*.
 
-  #+begin_src haskell
-    [ MailItem "name" "address" "query"
-    ...
-    ]
-  #+end_src
+ - Rate: Rate with which to update the plugin (in deciseconds).
 
-  or, using explicit record syntax:
+ - Example:
 
-  #+begin_src haskell
-    [ MailItem
-        { name    = "name"
-        , address = "address"
-        , query   = "query"
-        }
-      ...
-    ]
-  #+end_src
+   - A single =MailItem= that displays all unread threads from the given
+     address:
 
-  where
+     #+begin_src haskell
+       MailItem "mbs:" "soliditsallgood@mailbox.org" ""
+     #+end_src
 
-  - =name= is what gets printed in the status bar before the number of
-    new threads.
-  - =address= is the e-mail address of the recipient, i.e. we only query
-    mail that was send to this particular address (in more concrete
-    terms, we pass the address to the =to:= constructor when performing
-    the search). If =address= is empty, we search through all unread
-    mail, regardless of whom it was sent to.
-  - =query= is funneled to =notmuch search= verbatim. For the general
-    query syntax, consult =notmuch search --help=, as well as
-    =notmuch-search-terms(7)=. Note that the =unread= tag is *always*
-    added in front of the query and composed with it via an *and*.
+   - A single =MailItem= that displays all unread threads with
+     "[My-Subject]" somewhere in the title:
 
-- Rate: Rate with which to update the plugin (in deciseconds).
+     #+begin_src haskell
+       MailItem "S:" "" "subject:[My-Subject]"
+     #+end_src
 
-- Example:
+   - A full example of a =NotmuchMail= configuration:
 
-  - A single =MailItem= that displays all unread threads from the given
-    address:
+     #+begin_src haskell
+       Run NotmuchMail "mail"  -- name for the template string
+         [ -- All unread mail to the below address, but nothing that's tagged
+           -- with @lists@ or @haskell@.
+           MailItem "mbs:"
+                    "soliditsallgood@mailbox.org"
+                    "not tag:lists and not tag:haskell"
 
-    #+begin_src haskell
-      MailItem "mbs:" "soliditsallgood@mailbox.org" ""
-    #+end_src
+           -- All unread mail that has @[Haskell-Cafe]@ in the subject line.
+         , MailItem "C:" "" "subject:[Haskell-Cafe]"
 
-  - A single =MailItem= that displays all unread threads with
-    "[My-Subject]" somewhere in the title:
+           -- All unread mail that's tagged as @lists@, but not @haskell@.
+         , MailItem "H:" "" "tag:lists and not tag:haskell"
+         ]
+         600                   -- update every 60 seconds
+     #+end_src
 
-    #+begin_src haskell
-      MailItem "S:" "" "subject:[My-Subject]"
-    #+end_src
+** Music Monitors
+*** =MPD Args RefreshRate=
 
-  - A full example of a =NotmuchMail= configuration:
+ - This monitor will only be compiled if you ask for it using the
+   =with_mpd= flag. It needs [[http://hackage.haskell.org/package/libmpd/][libmpd]] 5.0 or later (available on Hackage).
 
-    #+begin_src haskell
-      Run NotmuchMail "mail"  -- name for the template string
-        [ -- All unread mail to the below address, but nothing that's tagged
-          -- with @lists@ or @haskell@.
-          MailItem "mbs:"
-                   "soliditsallgood@mailbox.org"
-                   "not tag:lists and not tag:haskell"
+ - Aliases to =mpd=
 
-          -- All unread mail that has @[Haskell-Cafe]@ in the subject line.
-        , MailItem "C:" "" "subject:[Haskell-Cafe]"
+ - Args: default monitor arguments. In addition you can provide =-P=,
+   =-S= and =-Z=, with an string argument, to represent the playing,
+   stopped and paused states in the =statei= template field. The
+   environment variables =MPD_HOST= and =MPD_PORT= are used to configure
+   the mpd server to communicate with, unless given in the additional
+   arguments =-p= (=--port=) and =-h= (=--host=). Also available:
 
-          -- All unread mail that's tagged as @lists@, but not @haskell@.
-        , MailItem "H:" "" "tag:lists and not tag:haskell"
-        ]
-        600                   -- update every 60 seconds
-    #+end_src
+   - =lapsed-icon-pattern=: dynamic string for current track position in
+     =ipat=.
 
-** =XPropertyLog PropName=
+ - Variables that can be used with the =-t/--template= argument: =bar=,
+   =vbar=, =ipat=, =state=, =statei=, =volume=, =length=, =lapsed=,
+   =remaining=, =plength= (playlist length), =ppos= (playlist position),
+   =flags= (ncmpcpp-style playback mode), =name=, =artist=, =composer=,
+   =performer=, =album=, =title=, =track=, =file=, =genre=, =date=
 
-- Aliases to =PropName=
-- Reads the X property named by =PropName= (a string) and displays its
-  value. The [[https://github.com/jaor/xmobar/raw/master/examples/xmonadpropwrite.hs][examples/xmonadpropwrite.hs script]] in xmobar's distribution
-  can be used to set the given property from the output of any other
-  program or script.
+ - Default template: =MPD: <state>=
 
-** =UnsafeXPropertyLog PropName=
+ - Example (note that you need "--" to separate regular monitor options
+   from MPD's specific ones):
 
-- Aliases to =PropName=
-- Same as =XPropertyLog=, but the input is not filtered to avoid
-  injection of actions (cf. =UnsafeXMonadLog=). The program writing the
-  value of the read property is responsible of performing any needed
-  cleanups.
+   #+begin_src haskell
+     Run MPD ["-t",
+              "<composer> <title> (<album>) <track>/<plength> <statei> [<flags>]",
+              "--", "-P", ">>", "-Z", "|", "-S", "><"] 10
+   #+end_src
 
-** =NamedXPropertyLog PropName Alias=
+*** =MPDX Args RefreshRate Alias=
 
-- Aliases to =Alias=
-- Same as =XPropertyLog=, but a custom alias can be specified.
+ Like =MPD= but uses as alias its last argument instead of "mpd".
 
-** =UnsafeNamedXPropertyLog PropName Alias=
+*** =Mpris1 PlayerName Args RefreshRate=
 
-- Aliases to =Alias=
-- Same as =UnsafeXPropertyLog=, but a custom alias can be specified.
+ - Aliases to =mpris1=
 
-** =Brightness Args RefreshRate=
+ - Requires [[http://hackage.haskell.org/package/dbus][dbus]] and [[http://hackage.haskell.org/package/text][text]] packages. To activate, pass the =with_mpris=
+   flag during compilation.
 
-- Aliases to =bright=
+ - PlayerName: player supporting MPRIS v1 protocol. Some players need
+   this to be an all lowercase name (e.g. "spotify"), but some others
+   don't.
 
-- Args: default monitor arguments, plus the following specif ones:
+ - Args: default monitor arguments.
 
-  - =-D=: directory in =/sys/class/backlight/= with files in it
-    (default: "acpi_video0")
-  - =-C=: file with the current brightness (default: actual_brightness)
-  - =-M=: file with the maximum brightness (default: max_brightness)
-  - =--brightness-icon-pattern=: dynamic string for current brightness
-    in =ipat=.
+ - Variables that can be used with the =-t/--template= argument:
+   =album=, =artist=, =arturl=, =length=, =title=, =tracknumber=
 
-- Variables that can be used with the =-t/--template= argument:
-  =vbar=, =percent=, =bar=, =ipat=
+ - Default template: =<artist> - <title>=
 
-- Default template: =<percent>=
+ - Example:
 
-- Example:
+   #+begin_src haskell
+     Run Mpris1 "clementine" ["-t", "<artist> - [<tracknumber>] <title>"] 10
+   #+end_src
 
-  #+begin_src haskell
-    Run Brightness ["-t", "<bar>"] 60
-  #+end_src
+*** =Mpris2 PlayerName Args RefreshRate=
 
-** =Kbd Opts=
+ - Aliases to =mpris2=
 
-- Registers to XKB/X11-Events and output the currently active keyboard
-  layout. Supports replacement of layout names.
+ - Requires [[http://hackage.haskell.org/package/dbus][dbus]] and [[http://hackage.haskell.org/package/text][text]] packages. To activate, pass the =with_mpris=
+   flag during compilation.
 
-- Aliases to =kbd=
+ - PlayerName: player supporting MPRIS v2 protocol. Some players need
+   this to be an all lowercase name (e.g. "spotify"), but some others
+   don't.
 
-- Opts is a list of tuples:
+ - Args: default monitor arguments.
 
-  - first element of the tuple is the search string
-  - second element of the tuple is the corresponding replacement
+ - Variables that can be used with the =-t/--template= argument:
+   =album=, =artist=, =arturl=, =length=, =title=, =tracknumber=,
+   =composer=, =genre=
 
-- Example:
+ - Default template: =<artist> - <title>=
 
-  #+begin_src haskell
-    Run Kbd [("us(dvorak)", "DV"), ("us", "US")]
-  #+end_src
+ - Example:
 
-** =Locks=
+   #+begin_src haskell
+     Run Mpris2 "spotify" ["-t", "<artist> - [<composer>] <title>"] 10
+   #+end_src
+** Network Monitors
+*** =Network Interface Args RefreshRate=
 
-- Displays the status of Caps Lock, Num Lock and Scroll Lock.
+ - Aliases to the interface name: so =Network "eth0" []= can be used as
+   =%eth0%=
+ - Thresholds refer to velocities expressed in Kb/s
+ - Args: default monitor arguments, plus:
 
-- Aliases to =locks=
+   - =--rx-icon-pattern=: dynamic string for reception rate in =rxipat=.
+   - =--tx-icon-pattern=: dynamic string for transmission rate in
+     =txipat=.
+   - =--up=: string used for the =up= variable value when the interface
+     is up.
 
-- Example:
+ - Variables that can be used with the =-t=/=--template= argument: =dev=,
+   =rx=, =tx=, =rxbar=, =rxvbar=, =rxipat=, =txbar=, =txvbar=, =txipat=,
+   =up=. Reception and transmission rates (=rx= and =tx=) are displayed
+   by default as Kb/s, without any suffixes, but you can set the =-S= to
+   "True" to make them displayed with adaptive units (Kb/s, Mb/s, etc.).
+ - Default template: =<dev>: <rx>KB|<tx>KB=
 
-  #+begin_src haskell
-    Run Locks
-  #+end_src
+*** =DynNetwork Args RefreshRate=
 
-** =CatInt n filename=
+ - Active interface is detected automatically
+ - Aliases to "dynnetwork"
+ - Thresholds are expressed in Kb/s
+ - Args: default monitor arguments, plus:
+
+ - =--rx-icon-pattern=: dynamic string for reception rate in =rxipat=.
+ - =--tx-icon-pattern=: dynamic string for transmission rate in =txipat=
+ - =--devices=: comma-separated list of devices to show.
+
+ - Variables that can be used with the =-t=/=--template= argument:
+   =dev=, =rx=, =tx=, =rxbar=, =rxvbar=, =rxipat=, =txbar=, =txvbar=,
+   =txipat=.
+
+ Reception and transmission rates (=rx= and =tx=) are displayed in Kbytes
+ per second, and you can set the =-S= to "True" to make them displayed
+ with units (the string "Kb/s").
+ - Default template: =<dev>: <rx>KB|<tx>KB=
+ - Example of usage of =--devices= option:
+
+     =["--", "--devices", "wlp2s0,enp0s20f41"]=
+
+*** =Wireless Interface Args RefreshRate=
+
+ - If set to "", first suitable wireless interface is used.
+ - Aliases to the interface name with the suffix "wi": thus,
+   =Wireless   "wlan0" []= can be used as =%wlan0wi%=, and
+   =Wireless "" []= as =%wi%=.
+ - Args: default monitor arguments, plus:
 
-- Reads and displays an integer from the file whose path is =filename=
-  (especially useful with files in =/sys=).
+   - =--quality-icon-pattern=: dynamic string for connection quality in
+     =qualityipat=.
 
-- Aliases as =catn= (e.g. =Cat 0= as =cat0=, etc.) so you can have
-  several.
+ - Variables that can be used with the =-t=/=--template= argument:
+   =ssid=, =signal=, =quality=, =qualitybar=, =qualityvbar=,
+   =qualityipat=
+ - Thresholds refer to link quality on a =[0, 100]= scale. Note that
+   =quality= is calculated from =signal= (in dBm) by a possibly lossy
+   conversion. It is also not taking into account many factors such as
+   noise level, air busy time, transcievers' capabilities and the others
+   which can have drastic impact on the link performance.
+ - Default template: =<ssid> <quality>=
+ - To activate this plugin you must pass the =with_nl80211= or the
+   =with_iwlib= flag during compilation.
+** Weather Monitors
+*** =Weather StationID Args RefreshRate=
 
-- Example:
+ - Aliases to the Station ID: so =Weather "LIPB" []= can be used in
+   template as =%LIPB%=
+ - Thresholds refer to temperature in the selected units
+ - Args: default monitor arguments, plus:
 
-  #+begin_src haskell
-    Run CatInt 0 "/sys/devices/platform/thinkpad_hwmon/fan1_input" [] 50
-  #+end_src
+   - =--weathers= /string/ : display a default string when the =weather=
+     variable is not reported.
 
-** =UVMeter=
+     - short option: =-w=
+     - Default: ""
 
-- Aliases to "uv" + station id. For example: =%uv Brisbane%= or
-  =%uv   Alice Springs%=
+   - =--useManager= /bool/ : Whether to use one single manager per
+     monitor for managing network connections or create a new one every
+     time a connection is made.
 
-- Args: default monitor arguments, plus:
+     - Short option: =-m=
+     - Default: True
 
-  - =--useManager= /bool/ : Whether to use one single manager per
-    monitor for managing network connections or create a new one every
-    time a connection is made.
+ - Variables that can be used with the =-t/--template= argument:
+   =station=, =stationState=, =year=, =month=, =day=, =hour=,
+   =windCardinal=, =windAzimuth=, =windMph=, =windKnots=, =windMs=,
+   =windKmh= =visibility=, =skyCondition=, =weather=, =tempC=, =tempF=,
+   =dewPointC=, =dewPointF=, =rh=, =pressure=
+ - Default template: =<station>: <tempC>C, rh <rh>% (<hour>)=
+ - Retrieves weather information from http://tgftp.nws.noaa.gov. Here is
+   an [[https://tgftp.nws.noaa.gov/data/observations/metar/decoded/CYLD.TXT][example]], also showcasing the kind of information that may be
+   extracted.
 
-    - Short option: =-m=
-    - Default: True
+*** =WeatherX StationID SkyConditions Args RefreshRate=
 
-- /Reminder:/ Keep the refresh rate high, to avoid making unnecessary
-  requests every time the plug-in is run.
+ - Works in the same way as =Weather=, but takes an additional argument,
+   a list of pairs from sky conditions to their replacement (typically a
+   unicode string or an icon specification).
+ - Use the variable =skyConditionS= to display the replacement of the
+   corresponding sky condition. All other =Weather= template variables
+   are available as well.
 
-- Station IDs can be found here:
-  http://www.arpansa.gov.au/uvindex/realtime/xml/uvvalues.xml
+ For example:
 
-- Example:
+ #+begin_src haskell
+   WeatherX "LEBL"
+            [ ("clear", "🌣")
+            , ("sunny", "🌣")
+            , ("mostly clear", "🌤")
+            , ("mostly sunny", "🌤")
+            , ("partly sunny", "⛅")
+            , ("fair", "🌑")
+            , ("cloudy","☁")
+            , ("overcast","☁")
+            , ("partly cloudy", "⛅")
+            , ("mostly cloudy", "🌧")
+            , ("considerable cloudiness", "⛈")]
+            ["-t", "<fn=2><skyConditionS></fn> <tempC>° <rh>%  <windKmh> (<hour>)"
+            , "-L","10", "-H", "25", "--normal", "black"
+            , "--high", "lightgoldenrod4", "--low", "darkseagreen4"]
+            18000
+ #+end_src
 
-  #+begin_src haskell
-    Run UVMeter "Brisbane" ["-H", "3", "-L", "3", "--low", "green", "--high", "red"] 900
-  #+end_src
+ As mentioned, the replacement string can also be an icon specification,
+ such as =("clear", "<icon=weather-clear.xbm/>")=.
+** Other Monitors
+*** =Brightness Args RefreshRate=
+
+ - Aliases to =bright=
+
+ - Args: default monitor arguments, plus the following specif ones:
+
+   - =-D=: directory in =/sys/class/backlight/= with files in it
+     (default: "acpi_video0")
+   - =-C=: file with the current brightness (default: actual_brightness)
+   - =-M=: file with the maximum brightness (default: max_brightness)
+   - =--brightness-icon-pattern=: dynamic string for current brightness
+     in =ipat=.
+
+ - Variables that can be used with the =-t/--template= argument:
+   =vbar=, =percent=, =bar=, =ipat=
+
+ - Default template: =<percent>=
+
+ - Example:
+
+   #+begin_src haskell
+     Run Brightness ["-t", "<bar>"] 60
+   #+end_src
+
+*** =CatInt n filename=
+
+ - Reads and displays an integer from the file whose path is =filename=
+   (especially useful with files in =/sys=).
+
+ - Aliases as =catn= (e.g. =Cat 0= as =cat0=, etc.) so you can have
+   several.
+
+ - Example:
+
+   #+begin_src haskell
+     Run CatInt 0 "/sys/devices/platform/thinkpad_hwmon/fan1_input" [] 50
+   #+end_src
+
+*** =CommandReader "/path/to/program" Alias=
+
+ - Runs the given program, and displays its standard output.
+
+*** =Uptime Args RefreshRate=
+
+ - Aliases to =uptime=
+ - Args: default monitor arguments. The low and high thresholds refer to
+   the number of days.
+ - Variables that can be used with the =-t/--template= argument: =days=,
+   =hours=, =minutes=, =seconds=. The total uptime is the sum of all
+   those fields. You can set the =-S= argument to =True= to add units to
+   the display of those numeric fields.
+ - Default template: =Up: <days>d <hours>h <minutes>m=
+
+*** =UVMeter=
+
+ - Aliases to "uv" + station id. For example: =%uv Brisbane%= or
+   =%uv   Alice Springs%=
+
+ - Args: default monitor arguments, plus:
+
+   - =--useManager= /bool/ : Whether to use one single manager per
+     monitor for managing network connections or create a new one every
+     time a connection is made.
+
+     - Short option: =-m=
+     - Default: True
+
+ - /Reminder:/ Keep the refresh rate high, to avoid making unnecessary
+   requests every time the plug-in is run.
+
+ - Station IDs can be found here:
+   http://www.arpansa.gov.au/uvindex/realtime/xml/uvvalues.xml
+
+ - Example:
+
+   #+begin_src haskell
+     Run UVMeter "Brisbane" ["-H", "3", "-L", "3", "--low", "green", "--high", "red"] 900
+   #+end_src
 
 * Interfacing with Window Managers
 

--- a/doc/plugins.org
+++ b/doc/plugins.org
@@ -1286,6 +1286,33 @@ choice.
   =StdinReader=. For instance, it allows you to (re)start xmobar outside
   xmonad.
 
+** =UnsafeXMonadLog=
+
+- Aliases to UnsafeXMonadLog
+- Displays any text received by xmobar on the =_XMONAD_LOG= atom.
+- Will not do anything to the text received. This means you can pass
+  xmobar dynamic actions. Be careful to escape (using =<raw=…>=) or
+  remove tags from dynamic text that you pipe through to xmobar in this
+  way.
+
+- Sample usage: Send the list of your workspaces, enclosed by actions
+  tags, to xmobar.  This enables you to switch to a workspace when you
+  click on it in xmobar!
+
+  #+begin_src shell
+    <action=`xdotool key alt+1`>ws1</action> <action=`xdotool key alt+1`>ws2</action>
+  #+end_src
+
+- If you use xmonad, It is advised that you still use =xmobarStrip= for
+  the =ppTitle= in your logHook:
+
+  #+begin_src haskell
+    myPP = defaultPP { ppTitle = xmobarStrip }
+    main = xmonad $ def
+      { logHook = dynamicLogString myPP >>= xmonadPropLog
+      }
+  #+end_src
+
 ** =StdinReader=
 
 - Aliases to StdinReader
@@ -1299,34 +1326,16 @@ choice.
 
 - Aliases to UnsafeStdinReader
 - Displays any text received by xmobar on its standard input.
-- Will not do anything to the text received. This means you can pass
-  dynamic actions via stdin. Be careful to escape (using =<raw=…>=) or
-  remove tags from dynamic text that you pipe-thru to xmobar's standard
-  input, e.g. window's title.
-- Sample usage: send to xmobar's stdin the list of your workspaces
-  enclosed by actions tags that switches the workspaces to be able to
-  switch workspaces by clicking on xmobar:
+- Similar to [[=UnsafeXMonadLog=][UnsafeXMonadLog]], in the sense that it does not strip any
+  actions from the received text, only using =stdin= and not a property
+  atom of the root window. Please be equally carefully when using this
+  as when using =UnsafeXMonadLog=!
 
-  #+begin_src shell
-    <action=`xdotool key alt+1`>ws1</action> <action=`xdotool key alt+1`>ws2</action>
-  #+end_src
 
-** =UnsafeXMonadLog=
 
-- Aliases to UnsafeXMonadLog
 
-- Similar to =StdinReader= versus =UnsafeStdinReader=, this does not
-  strip =<action ...>= tags from XMonad's =_XMONAD_LOG=.
 
-- It is advised that you still use =xmobarStrip= for the ppTitle in your
-  logHook:
 
-  #+begin_src haskell
-    myPP = defaultPP { ppTitle = xmobarStrip }
-    main = xmonad $ def
-      { logHook = dynamicLogString myPP >>= xmonadPropLog
-      }
-  #+end_src
 
 ** =CommandReader "/path/to/program" Alias=
 


### PR DESCRIPTION
This implements the idea

> idea for the future: it'd might be useful to categorize our monitors
> in groups with their own section headings, e.g. "Battery monitors",
> "Email".... and so on.

from #514

It also recommends (visually, by simply listing them first)
property-based logging over using pipes, due to the various issues with
pipe-based solutions.