### PR TITLE
Extract compiling, writing a plugin to their own files

### DIFF
--- a/contributing.org
+++ b/contributing.org
@@ -19,9 +19,10 @@ this case please don't merge any branches, but actually rebase! This is
 a very nifty feature that =git= offers in order to remain a clean
 history.
 
-Give your commits descriptive names!  Further, it's also highly recommended to
-add a description of /why/ you made a certain change.  The syntax for this is
-*commit message*, blank line, *more description*.  For example:
+Give your commits descriptive names!  Further, it's also highly
+recommended to add a description of /why/ you made a certain change.
+The syntax for this is *commit message*, blank line, *more description*.
+For example:
 
   #+begin_src shell
     Commit Message (max. 50 characters)
@@ -48,72 +49,5 @@ request:
 
 Please also remember to update the =changelog.md= file, as well as any
 other documentation that your pull request touches upon.  For example,
-if you add a new plugin you should update the [[./doc/plugins.org][plugins documentation]].
-
-* Writing Your Own Plugin
-
-Writing a plugin for xmobar is very simple!
-
-First, you need to create a data type with at least one constructor.
-Next you must declare this data type an instance of the =Exec= class, by
-defining the one needed method (alternatively =start= or =run=) and 3
-optional ones (=alias=, =rate=, and =trigger=):
-
-#+begin_src haskell
-  start   :: e -> (String -> IO ()) -> IO ()
-  run     :: e -> IO String
-  rate    :: e -> Int
-  alias   :: e -> String
-  trigger :: e -> (Maybe SignalType -> IO ()) -> IO ()
-#+end_src
-
-=start= must receive a callback to be used to display the =String=
-produced by the plugin. This method can be used for plugins that need to
-perform asynchronous actions. See =src/Xmobar/Plugins/PipeReader.hs= for
-an example.
-
-=run= can be used for simpler plugins. If you define only =run= the
-plugin will be run every second. To overwrite this default you just need
-to implement =rate=, which must return the number of tenth of seconds
-between every successive runs. See [[https://github.com/jaor/xmobar/blob/master/examples/xmobar.hs][examples/xmobar.hs]] for an example of
-a plugin that runs just once, and [[https://github.com/jaor/xmobar/blob/master/src/Xmobar/Plugins/Date.hs][src/Xmobar/Plugins/Date.hs]] for one
-that implements =rate=.
-
-Notice that Date could be implemented as:
-
-#+begin_src haskell
-  instance Exec Date where
-      alias (Date _ a _) = a
-      start (Date f _ r) = date f r
-
-  date :: String -> Int -> (String -> IO ()) -> IO ()
-  date format r callback = do go
-      where go = do
-              t <- toCalendarTime =<< getClockTime
-              callback $ formatCalendarTime defaultTimeLocale format t
-              tenthSeconds r >> go
-#+end_src
-
-This implementation is equivalent to the one you can read in
-=Plugins/Date.hs=.
-
-=alias= is the name to be used in the output template. Default alias
-will be the data type constructor.
-
-After that your type constructor can be used as an argument for the
-Runnable type constructor =Run= in the =commands= list of the
-configuration options.
-
-** Using a Plugin
-
-To use your new plugin, you need to use a pure Haskell configuration for
-xmobar, and load your definitions there. You can see an example in
-[[./examples/xmobar.hs][examples/xmobar.hs]] showing you how to write a Haskell configuration that
-uses a new plugin, all in one file.
-
-When xmobar runs with the full path to that Haskell file as its argument
-(or if you put it in =~/.config/xmobar/xmobar.hs=), and with the xmobar
-library installed (e.g., with =cabal install --lib xmobar=), the Haskell
-code will be compiled as needed, and the new executable spawned for you.
-
-That's it!
+if you add a new plugin (see [[./doc/write-your-own-plugin.org][here]] for more information) you should
+update the [[./doc/plugins.org][plugins documentation]].

--- a/doc/compiling.org
+++ b/doc/compiling.org
@@ -1,0 +1,110 @@
+* Compiling Xmobar from Source
+
+If you don't have =cabal-install= installed, you can get xmobar's source
+code in a variety of ways:
+
+- From [[http://hackage.haskell.org/package/xmobar/][Hackage]]. Just download the latest release from xmobar's hackage
+  page.
+
+- From [[http://github.com/jaor/xmobar/][Github]]. There are also tarballs available for every tagged
+  release on [[https://github.com/jaor/xmobar/releases][Github's releases page]]
+
+- From the bleeding edge repo. If you prefer to live dangerously, just
+  get the latest and greatest (and buggiest, I guess) using git:
+
+  #+begin_src shell
+    git clone git://github.com/jaor/xmobar
+  #+end_src
+
+If you have cabal installed, you can now use it from within xmobar's
+source tree:
+
+#+begin_src shell
+  cabal install --flags="all_extensions"
+#+end_src
+
+There is also a =stack.yaml= file that will allow you to install the
+xmobar executable with
+
+#+begin_src shell
+  stack install
+#+end_src
+
+See the =stack.yaml= file for the enabled extensions. You can also pass
+them to =stack= directly:
+
+#+begin_src shell
+  stack install --flag xmobar:all_extensions
+#+end_src
+
+** Optional features
+
+You can configure xmobar to include some optional plugins and features,
+which are not compiled by default. To that end, you need to add one or
+more flags to either the cabal install command or the configure setup
+step, as shown in the examples above.
+
+Extensions need additional libraries (listed below) that will be
+automatically downloaded and installed if you're using cabal install.
+Otherwise, you'll need to install them yourself.
+
+- =with_dbus= Enables support for DBUS by making xmobar to publish a
+  service on the session bus. Requires the [[http://hackage.haskell.org/package/dbus][dbus]] package.
+
+- =with_threaded= Uses GHC's threaded runtime. Use this option if xmobar
+  enters a high-CPU regime right after starting.
+
+- =with_utf8= UTF-8 support. Requires the [[http://hackage.haskell.org/package/utf8-string/][utf8-string]] package.
+
+- =with_xft= Antialiased fonts. Requires the [[http://hackage.haskell.org/package/X11-xft/][X11-xft]] package. This
+  option automatically enables UTF-8. To use XFT fonts you need to use
+  the =xft:= prefix in the =font= configuration option. For instance:
+
+  #+begin_src haskell
+    font = "xft:Times New Roman-10:italic"
+  #+end_src
+
+  Or to have fallback fonts, just separate them by commas:
+
+  #+begin_src haskell
+    font = "xft:Open Sans:size=9,WenQuanYi Zen Hei:size=9"
+  #+end_src
+
+- =with_mpd= Enables support for the [[http://mpd.wikia.com/][MPD]] daemon. Requires the [[http://hackage.haskell.org/package/libmpd/][libmpd]]
+  package.
+
+- =with_mpris= Enables support for MPRIS v1/v2 protocol. Requires the
+  [[http://hackage.haskell.org/package/dbus][dbus]] and [[http://hackage.haskell.org/package/text][text]] packages.
+
+- =with_inotify= Support for inotify in modern Linux kernels. This
+  option is needed for the MBox and Mail plugins to work. Requires the
+  [[http://hackage.haskell.org/package/hinotify/][hinotify]] package.
+
+- =with_nl80211= Support for wireless cards on Linux via nl80211 (all
+  upstream drivers). Enables the Wireless plugin. Requires [netlink] and
+  [cereal] packages.
+
+- =with_iwlib= Support for wireless cards via Wext ioctls (deprecated).
+  Enables the Wireless plugin. No Haskell library is required, but you
+  will need the [[http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/Tools.html][iwlib]] C library and headers in your system (e.g.,
+  install =libiw-dev= in Debian-based systems or =wireless_tools= on
+  Arch Linux). Conflicts with =with_nl80211=.
+
+- =with_alsa= Support for ALSA sound cards. Enables the Volume plugin.
+  Requires the [[http://hackage.haskell.org/package/alsa-mixer][alsa-mixer]] package.  To install the latter, you'll need
+  the [[http://packages.debian.org/stable/libasound2-dev][libasound]] C library and headers in your system (e.g., install
+  =libasound2-dev= in Debian-based systems).
+
+- =with_datezone= Support for other timezones. Enables the DateZone
+  plugin. Requires [[http://hackage.haskell.org/package/timezone-olson][timezone-olson]] and [[http://hackage.haskell.org/package/timezone-series][timezone-series]] package.
+
+- =with_xpm= Support for xpm image file format. This will allow loading
+  .xpm files in =<icon>=. Requires the [[http://cgit.freedesktop.org/xorg/lib/libXpm][libXpm]] C library.
+
+- =with_uvmeter= Enables UVMeter plugin. The plugin shows UV data for
+  Australia.
+
+- =with_weather= Support to display weather information. Enables Weather
+  plugin.
+
+- =all_extensions= Enables all the extensions above.

--- a/doc/write-your-own-plugin.org
+++ b/doc/write-your-own-plugin.org
@@ -1,0 +1,74 @@
+* Writing Your Own Plugin
+
+Writing a plugin for xmobar is very simple!
+
+First, you need to create a data type with at least one constructor.
+Next you must declare this data type an instance of the =Exec= class, by
+defining the one needed method (alternatively =start= or =run=) and 3
+optional ones (=alias=, =rate=, and =trigger=):
+
+#+begin_src haskell
+  start   :: e -> (String -> IO ()) -> IO ()
+  run     :: e -> IO String
+  rate    :: e -> Int
+  alias   :: e -> String
+  trigger :: e -> (Maybe SignalType -> IO ()) -> IO ()
+#+end_src
+
+=start= must receive a callback to be used to display the =String=
+produced by the plugin. This method can be used for plugins that need to
+perform asynchronous actions. See =src/Xmobar/Plugins/PipeReader.hs= for
+an example.
+
+=run= can be used for simpler plugins. If you define only =run= the
+plugin will be run every second. To overwrite this default you just need
+to implement =rate=, which must return the number of tenth of seconds
+between every successive runs. See [[https://github.com/jaor/xmobar/blob/master/examples/xmobar.hs][examples/xmobar.hs]] for an example of
+a plugin that runs just once, and [[https://github.com/jaor/xmobar/blob/master/src/Xmobar/Plugins/Date.hs][src/Xmobar/Plugins/Date.hs]] for one
+that implements =rate=.
+
+Notice that Date could be implemented as:
+
+#+begin_src haskell
+  instance Exec Date where
+      alias (Date _ a _) = a
+      start (Date f _ r) = date f r
+
+  date :: String -> Int -> (String -> IO ()) -> IO ()
+  date format r callback = do go
+      where go = do
+              t <- toCalendarTime =<< getClockTime
+              callback $ formatCalendarTime defaultTimeLocale format t
+              tenthSeconds r >> go
+#+end_src
+
+Modulo some technicalities like refreshing the time-zone in a clever
+way, this implementation is equivalent to the one you can read in
+=Plugins/Date.hs=.
+
+=alias= is the name to be used in the output template. Default alias
+will be the data type constructor.
+
+After that your type constructor can be used as an argument for the
+Runnable type constructor =Run= in the =commands= list of the
+configuration options.
+
+If your plugin only implements =alias= and =start=, then it is advisable
+to put it into the =Xmobar/Plugins/Monitors= directory and use one of
+the many =run*= functions in [[../src/Xmobar/Plugins/Monitors/Common/Run.hs][Xmobar.Plugins.Monitors.Run]] in order to
+define =start=. The =Exec= instance should then live in
+[[../src/Xmobar/Plugins/Monitors.hs][Xmobar.Plugins.Monitors]].
+
+** Using a Plugin
+
+To use your new plugin, you need to use a pure Haskell configuration for
+xmobar, and load your definitions there. You can see an example in
+[[../examples/xmobar.hs][examples/xmobar.hs]] showing you how to write a Haskell configuration that
+uses a new plugin, all in one file.
+
+When xmobar runs with the full path to that Haskell file as its argument
+(or if you put it in =~/.config/xmobar/xmobar.hs=), and with the xmobar
+library installed (e.g., with =cabal install --lib xmobar=), the Haskell
+code will be compiled as needed, and the new executable spawned for you.
+
+That's it!

--- a/readme.org
+++ b/readme.org
@@ -40,6 +40,12 @@ item below.
   apt install xmobar
 #+end_src
 
+*** OpenSUSE
+
+#+begin_src shell
+  zypper install xmobar
+#+end_src
+
 *** Void Linux
 
 #+begin_src shell

--- a/readme.org
+++ b/readme.org
@@ -23,10 +23,9 @@ This is the [[https://xmobar.org/changelog.html][changelog]] for recent releases
 * Installation
 ** From your Systems Package Manager
 
-Xmobar is probably available from your distribution package manager!
-Most distributions do compile with the =all_extensions= flag, so you
-don't have to. For more information on that, see the [[Optional features][optional features]]
-item below.
+Xmobar is probably available from your distributions package manager!
+Most distributions compile xmobar with the =all_extensions= flag, so you
+don't have to.
 
 *** Arch Linux
 
@@ -64,9 +63,9 @@ Xmobar is available from [[http://hackage.haskell.org/package/xmobar/][Hackage]]
 Starting with version 0.35.1, xmobar now requires at least GHC version
 8.4.x. to build. See [[https://github.com/jaor/xmobar/issues/461][this issue]] for more information.
 
-See below for a list of optional compilation flags that will enable some
-optional plugins. For instance, to install xmobar with all the bells and
-whistles, use:
+See [[file:doc/compiling.org][compiling]] for a list of optional compilation flags that will enable
+some optional plugins. For instance, to install xmobar with all the
+bells and whistles (this is probably what you want), use:
 
 #+begin_src shell
   cabal install xmobar --flags="all_extensions"
@@ -74,118 +73,11 @@ whistles, use:
 
 ** From source
 
-If you don't have =cabal-install= installed, you can get xmobar's source
-code in a variety of ways:
-
-- From [[http://hackage.haskell.org/package/xmobar/][Hackage]]. Just download the latest release from xmobar's hackage
-  page.
-
-- From [[http://github.com/jaor/xmobar/][Github]]. There are also tarballs available for every tagged
-  release on [[https://github.com/jaor/xmobar/releases][Github's releases page]]
-
-- From the bleeding edge repo. If you prefer to live dangerously, just
-  get the latest and greatest (and buggiest, I guess) using git:
-
-  #+begin_src shell
-    git clone git://github.com/jaor/xmobar
-  #+end_src
-
-If you have cabal installed, you can now use it from within xmobar's
-source tree:
-
-#+begin_src shell
-  cabal install --flags="all_extensions"
-#+end_src
-
-There is also a barebones =stack.yaml= file that will allow you to
-install the xmobar executable with
-
-#+begin_src shell
-  stack install
-#+end_src
-
-See the =stack.yaml= file for the enabled extensions. You can also pass
-them to =stack= directly:
-
-#+begin_src shell
-  stack install --flag xmobar:all_extensions
-#+end_src
-
-** Optional features
-
-You can configure xmobar to include some optional plugins and features,
-which are not compiled by default. To that end, you need to add one or
-more flags to either the cabal install command or the configure setup
-step, as shown in the examples above.
-
-Extensions need additional libraries (listed below) that will be
-automatically downloaded and installed if you're using cabal install.
-Otherwise, you'll need to install them yourself.
-
-- =with_dbus= Enables support for DBUS by making xmobar to publish a
-  service on the session bus. Requires the [[http://hackage.haskell.org/package/dbus][dbus]] package.
-
-- =with_threaded= Uses GHC's threaded runtime. Use this option if xmobar
-  enters a high-CPU regime right after starting.
-
-- =with_utf8= UTF-8 support. Requires the [[http://hackage.haskell.org/package/utf8-string/][utf8-string]] package.
-
-- =with_xft= Antialiased fonts. Requires the [[http://hackage.haskell.org/package/X11-xft/][X11-xft]] package. This
-  option automatically enables UTF-8. To use XFT fonts you need to use
-  the =xft:= prefix in the =font= configuration option. For instance:
-
-  #+begin_src haskell
-    font = "xft:Times New Roman-10:italic"
-  #+end_src
-
-  Or to have fallback fonts, just separate them by commas:
-
-  #+begin_src haskell
-    font = "xft:Open Sans:size=9,WenQuanYi Zen Hei:size=9"
-  #+end_src
-
-- =with_mpd= Enables support for the [[http://mpd.wikia.com/][MPD]] daemon. Requires the [[http://hackage.haskell.org/package/libmpd/][libmpd]]
-  package.
-
-- =with_mpris= Enables support for MPRIS v1/v2 protocol. Requires the
-  [[http://hackage.haskell.org/package/dbus][dbus]] and [[http://hackage.haskell.org/package/text][text]] packages.
-
-- =with_inotify= Support for inotify in modern Linux kernels. This
-  option is needed for the MBox and Mail plugins to work. Requires the
-  [[http://hackage.haskell.org/package/hinotify/][hinotify]] package.
-
-- =with_nl80211= Support for wireless cards on Linux via nl80211 (all
-  upstream drivers). Enables the Wireless plugin. Requires [netlink] and
-  [cereal] packages.
-
-- =with_iwlib= Support for wireless cards via Wext ioctls (deprecated).
-  Enables the Wireless plugin. No Haskell library is required, but you
-  will need the [[http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/Tools.html][iwlib]] C library and headers in your system (e.g.,
-  install =libiw-dev= in Debian-based systems or =wireless_tools= on
-  Arch Linux). Conflicts with =with_nl80211=.
-
-- =with_alsa= Support for ALSA sound cards. Enables the Volume plugin.
-  Requires the [[http://hackage.haskell.org/package/alsa-mixer][alsa-mixer]] package.  To install the latter, you'll need
-  the [[http://packages.debian.org/stable/libasound2-dev][libasound]] C library and headers in your system (e.g., install
-  =libasound2-dev= in Debian-based systems).
-
-- =with_datezone= Support for other timezones. Enables the DateZone
-  plugin. Requires [[http://hackage.haskell.org/package/timezone-olson][timezone-olson]] and [[http://hackage.haskell.org/package/timezone-series][timezone-series]] package.
-
-- =with_xpm= Support for xpm image file format. This will allow loading
-  .xpm files in =<icon>=. Requires the [[http://cgit.freedesktop.org/xorg/lib/libXpm][libXpm]] C library.
-
-- =with_uvmeter= Enables UVMeter plugin. The plugin shows UV data for
-  Australia.
-
-- =with_weather= Support to display weather information. Enables Weather
-  plugin.
-
-- =all_extensions= Enables all the extensions above.
+See [[file:doc/compiling.org][compiling]].
 
 * Running xmobar
 
-You can now run xmobar with:
+You can run xmobar with:
 
 #+begin_src shell
   xmobar /path/to/config &

--- a/readme.org
+++ b/readme.org
@@ -209,8 +209,10 @@ Since 0.14 xmobar reacts to SIGUSR1 and SIGUSR2:
 - If you want to jump straight into configuring xmobar, head over to the
   [[./doc/quick-start.org][quick-start]] guide.
 
-- If you want to know how to write your own plugin, or how to contribute
-  to the xmobar project, check out [[contributing.org][contributing]].
+- If you want to know how to contribute to the xmobar project, check out
+  [[contributing.org][contributing]].
+
+- If you want to write your own plugins, see [[./doc/write-your-own-plugin.org][write-your-own-plugin]].
 
 * Authors and credits
 


### PR DESCRIPTION
This implements two suggestions of yours from #514, namely

  1. Putting all the information related to compiling its their own
     `.org` file
  2. Putting all the information related to writing your own plugins
     (I'm not sure about the name of the file here, but it fits, I
     suppose :) in its own `.org` file