### PR TITLE
Fix typo `DRTSOPTS` -> `RTSOPTS`

### DIFF
--- a/src/Xmobar/App/Compile.hs
+++ b/src/Xmobar/App/Compile.hs
@@ -165,7 +165,7 @@ recompile confDir dataDir execName force verb = liftIO $ do
 #ifdef THREADED_RUNTIME
                   ++ ["-threaded"]
 #endif
-#ifdef DRTSOPTS
+#ifdef RTSOPTS
                   ++ ["-rtsopts", "-with-rtsopts", "-V0"]
 #endif
                   ++ ["-o", bin]


### PR DESCRIPTION
The cpp option `-DRTSOPTS` results in `RTSOPTS` being defined.