### PR TITLE
Fix off-by-one in strut calculation for Static position

### DIFF
--- a/src/Xmobar/X11/Text.hs
+++ b/src/Xmobar/X11/Text.hs
@@ -118,7 +118,7 @@ textExtents (Core fs) s = do
   return (a,d)
 textExtents (Utf8 fs) s = do
   let (_,rl)  = wcTextExtents fs s
-      ascent  = fromIntegral $ - (rect_y rl)
+      ascent  = fromIntegral $ negate (rect_y rl)
       descent = fromIntegral $ rect_height rl + fromIntegral (rect_y rl)
   return (ascent, descent)
 #ifdef XFT

--- a/src/Xmobar/X11/Window.hs
+++ b/src/Xmobar/X11/Window.hs
@@ -175,7 +175,7 @@ getStaticStrutValues (Static cx cy cw ch) rwh
     where st = cy + ch
           sb = rwh - cy
           xs = cx -- a simple calculation for horizontal (x) placement
-          xe = xs + cw
+          xe = xs + cw - 1
 getStaticStrutValues _ _ = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
 drawBorder :: Border -> Int -> Display -> Drawable -> GC -> Pixel


### PR DESCRIPTION
Pixel intervals in _NET_WM_STRUT_PARTIAL are closed, not open [1], so xmobar of width 1920 at x=0 needs to be encoded as ⟨0, 1919⟩, not ⟨0, 1920). The code already does this for Top/Bottom positioning, but Static has been buggy for years.

[1]: https://specifications.freedesktop.org/wm-spec/1.5/ar01s05.html#idm46075117229424

Fixes: https://old.reddit.com/r/xmonad/comments/mynegr/xmobar_dual_monitor_bug/
Fixes: https://github.com/jaor/xmobar/issues/530