### PR TITLE
Revert "Conditional encoding …" and "Avoid double utf8 encoding" (#482)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ _Bug fixes_
   - Fix off-by-one in strut calculation for `Static` position which reserved
     space for the panel than necessary and caused issues in some multi-head
     setups (fixes #530).
+  - Revert the double-UTF-8 encoding workarounds of 0.36 (#482), as they're no
+    longer necessary with xmonad-contrib master, and aren't needed with any
+    released version of xmonad-contrib either.
 
 ## Version 0.37 (November, 2020)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+## Version 0.38 (unreleased)
+
+_Bug fixes_
+
+  - Fix off-by-one in strut calculation for `Static` position which reserved
+    space for the panel than necessary and caused issues in some multi-head
+    setups (fixes #530).
+
 ## Version 0.37 (November, 2020)
 
 _New features_

--- a/src/Xmobar/X11/MinXft.hsc
+++ b/src/Xmobar/X11/MinXft.hsc
@@ -161,16 +161,10 @@ withAXftDraw d p v c act = do
 foreign import ccall "XftDrawStringUtf8"
   cXftDrawStringUtf8 :: AXftDraw -> AXftColor -> AXftFont -> CInt -> CInt -> Ptr (#type FcChar8) -> CInt -> IO ()
 
--- Fixes https://github.com/jaor/xmobar/issues/476
-utf8EncodeString :: Num b => String -> [b]
-utf8EncodeString str = if UTF8.isUTF8Encoded str
-                       then map (fi . ord) str
-                       else map fi (UTF8.encode str)
-
 drawXftString :: (Integral a1, Integral a) =>
                  AXftDraw -> AXftColor -> AXftFont -> a -> a1 -> String -> IO ()
 drawXftString d c f x y string =
-    withArrayLen (utf8EncodeString string)
+    withArrayLen (map fi (UTF8.encode string))
       (\len ptr -> cXftDrawStringUtf8 d c f (fi x) (fi y) ptr (fi len))
 
 drawXftString' :: AXftDraw ->


### PR DESCRIPTION
This reverts commits c6669e26e1 (partially; changelog entry kept), 73e02934d6, 78efa5900a.

These commits were introduced as a workaround for a double UTF-8 encoding bug in xmonad-contrib which itself was meant to be a fix/workaround for another issue. We have now identified the underlying issue and fixed it right at the root, so this entire cascade of hacky (and wrong) workarounds can be safely reverted. Thankfully, none of the xmonad-contrib hacks made it into a release, so there's no backward compat to worry about.

Should anyone be interested in the details, https://github.com/xmonad/xmonad-contrib/commit/63e31ccd8d2865863778207b679f806941bf2788 provides a summary and links to all the related issues and PRs.

Related: https://github.com/jaor/xmobar/pull/482
Related: https://github.com/jaor/xmobar/issues/476
Related: https://github.com/xmonad/xmonad-contrib/commit/63e31ccd8d2865863778207b679f806941bf2788
Related: https://github.com/xmonad/xmonad-contrib/pull/471
Related: https://github.com/xmonad/xmonad-contrib/issues/377

---

(also, added changelog entry for #538)