### PR TITLE
Fix delayed reaction to USR1/2 signals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ _Bug fixes_
   - Revert the double-UTF-8 encoding workarounds of 0.36 (#482), as they're no
     longer necessary with xmonad-contrib master, and aren't needed with any
     released version of xmonad-contrib either.
+  - Fix slow reactions to SIGUSR1/2 signals (reposition, change screen).
 
 ## Version 0.37 (November, 2020)
 

--- a/src/Xmobar/X11/Draw.hs
+++ b/src/Xmobar/X11/Draw.hs
@@ -89,7 +89,7 @@ drawInWin wr@(Rectangle _ _ wid ht) ~[left,center,right] = do
     liftIO $ freeGC d gc
     liftIO $ freePixmap d p
     -- resync
-    liftIO $ sync d True
+    liftIO $ sync d False
 
 verticalOffset :: (Integral b, Integral a, MonadIO m) =>
                   a -> Widget -> XFont -> Int -> Config -> m b

--- a/src/Xmobar/X11/Window.hs
+++ b/src/Xmobar/X11/Window.hs
@@ -69,6 +69,7 @@ repositionWin d win fs c = do
       r = setPosition c (position c) srs (fromIntegral ht)
   moveResizeWindow d win (rect_x r) (rect_y r) (rect_width r) (rect_height r)
   setStruts r c d win srs
+  sync d False
   return r
 
 fi :: (Integral a, Num b) => a -> b


### PR DESCRIPTION
While using xmobar to reproduce/fix a bug in xmonad I noticed that
xmobar doesn't react immediately to the signals to reposition or change
screen.

Apparently none of the Xlib functions called from `repositionWin` flush
the Xlib output buffer (XMoveResizeWindow is known to not flush,
although it's unfortunately not documented), so when compiled with the
threaded runtime that runs XNextEvent in a separate thread, the
reposition is sent to the X server only later when other stuff happens.
With all monitors set to refresh once a minute, this can take a looong
time.

(It's entirely possible this happens even without the threaded runtime,
I didn't test that, sorry.)

The fix is to call XSync at the end of `repositionWin`.

While at it, I spotted that drawInWin calls XSync with discard=true,
which seems like a mistake. We don't want to discard any events, do we?
(In practice, I'd expect the `eventer` thread to read all events even
before the drawing thread manages to discard them, so even if this
discarding XSync ever had any reason to be there, I don't think it does
anything meaningful these days. I may be wrong, though.)