### PR TITLE
Add k10temp monitor

### DIFF
--- a/doc/plugins.org
+++ b/doc/plugins.org
@@ -455,6 +455,39 @@ something like:
                         "-l", "green", "-n", "yellow", "-h", "red",
                         "--", "--mintemp", "20", "--maxtemp", "100"] 50
    #+end_src
+
+*** =K10Temp Slot Args RefreshRate=
+
+ - Aliases to =k10temp=
+
+ - Slot: The PCI slot address of the k10temp device
+
+ - Args: default monitor arguments
+
+ - Thresholds refer to temperature in degrees
+
+ - Variables that can be used with the =-t/--template= argument:
+   =Tctl=, =Tdie=, =Tccd1=, .., =Tccd8=
+
+ - Default template: =Temp: <Tdie>C=
+
+ - This monitor requires k10temp module to be loaded in kernel
+
+ - It is important to note that not all measurements are available
+   on on all models of processor. Of particular importance - Tdie
+   (used in the default template) may not be present on processors
+   prior to Zen (17h). Tctl, however, may be offset from the real
+   temperature and so is not used by default.
+
+ - Example:
+
+   #+begin_src haskell
+     Run CoreTemp ["-t", "Temp: <Tdie>C|<Tccd1>C",
+                   "-L", "40", "-H", "60",
+                   "-l", "lightblue", "-n", "gray90", "-h", "red"] 50
+   #+end_src
+
+
 *** =Memory Args RefreshRate=
 
  - Aliases to =memory=

--- a/src/Xmobar/Plugins/Monitors.hs
+++ b/src/Xmobar/Plugins/Monitors.hs
@@ -35,6 +35,7 @@ import Xmobar.Plugins.Monitors.ThermalZone
 import Xmobar.Plugins.Monitors.CpuFreq
 import Xmobar.Plugins.Monitors.CoreTemp
 import Xmobar.Plugins.Monitors.MultiCoreTemp
+import Xmobar.Plugins.Monitors.K10Temp
 import Xmobar.Plugins.Monitors.Disk
 import Xmobar.Plugins.Monitors.Top
 import Xmobar.Plugins.Monitors.Uptime
@@ -74,6 +75,7 @@ data Monitors = Network      Interface   Args Rate
               | CpuFreq      Args        Rate
               | CoreTemp     Args        Rate
               | MultiCoreTemp Args       Rate
+              | K10Temp      Slot        Args Rate
               | TopProc      Args        Rate
               | TopMem       Args        Rate
               | Uptime       Args        Rate
@@ -113,6 +115,7 @@ type ZoneNo    = Int
 type Interface = String
 type Rate      = Int
 type DiskSpec  = [(String, String)]
+type Slot      = String
 
 instance Exec Monitors where
 #ifdef WEATHER
@@ -136,6 +139,7 @@ instance Exec Monitors where
     alias (TopMem _ _) = "topmem"
     alias (CoreTemp _ _) = "coretemp"
     alias (MultiCoreTemp _ _) = "multicoretemp"
+    alias (K10Temp _ _ _) = "k10temp"
     alias DiskU {} = "disku"
     alias DiskIO {} = "diskio"
     alias (Uptime _ _) = "uptime"
@@ -181,6 +185,7 @@ instance Exec Monitors where
     start (CpuFreq a r) = runM a cpuFreqConfig runCpuFreq r
     start (CoreTemp a r) = runM a coreTempConfig runCoreTemp r
     start (MultiCoreTemp a r) = startMultiCoreTemp a r
+    start (K10Temp s a r) = runM (a ++ [s]) k10TempConfig runK10Temp r
     start (DiskU s a r) = runM a diskUConfig (runDiskU s) r
     start (DiskIO s a r) = startDiskIO s a r
     start (Uptime a r) = runM a uptimeConfig runUptime r

--- a/src/Xmobar/Plugins/Monitors.hs
+++ b/src/Xmobar/Plugins/Monitors.hs
@@ -139,7 +139,7 @@ instance Exec Monitors where
     alias (TopMem _ _) = "topmem"
     alias (CoreTemp _ _) = "coretemp"
     alias (MultiCoreTemp _ _) = "multicoretemp"
-    alias (K10Temp _ _ _) = "k10temp"
+    alias K10Temp {} = "k10temp"
     alias DiskU {} = "disku"
     alias DiskIO {} = "diskio"
     alias (Uptime _ _) = "uptime"

--- a/src/Xmobar/Plugins/Monitors/K10Temp.hs
+++ b/src/Xmobar/Plugins/Monitors/K10Temp.hs
@@ -1,0 +1,43 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Plugins.Monitors.CoreTemp
+-- Copyright   :  (c) Juraj Hercek
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  Juraj Hercek <juhe_haskell@hck.sk>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- A temperature monitor that works with AMD CPUs for Xmobar
+--
+-----------------------------------------------------------------------------
+
+module Xmobar.Plugins.Monitors.K10Temp where
+
+import Xmobar.Plugins.Monitors.Common
+
+import Data.Char (isDigit)
+
+-- |
+-- K10 temperature default configuration. Default template contains only the
+-- die temperature, user should specify custom template in order to get more
+-- ccd or IO die temperatures.
+k10TempConfig :: IO MConfig
+k10TempConfig = mkMConfig
+       "Temp: <Tdie>C" -- template
+       ["Tctl", "Tdie", "Tccd1", "Tccd2", "Tccd3"
+       ,"Tccd4", "Tccd5", "Tccd6", "Tccd7", "Tccd8"
+       ] -- available replacements
+
+-- |
+-- Function retrieves monitor string holding the temperature
+-- (or temperatures)
+runK10Temp :: [String] -> Monitor String
+runK10Temp args = do
+   dn <- getConfigValue decDigits
+   failureMessage <- getConfigValue naString
+   let slot = head args
+       path = ["/sys/bus/pci/drivers/k10temp/" ++ slot ++ "/hwmon/hwmon", "/temp", "_input"]
+       divisor = 1e3 :: Double
+       show' = showDigits (max 0 dn)
+   checkedDataRetrieval failureMessage [path] Nothing (/divisor) show'

--- a/src/Xmobar/Plugins/Monitors/K10Temp.hs
+++ b/src/Xmobar/Plugins/Monitors/K10Temp.hs
@@ -16,8 +16,6 @@ module Xmobar.Plugins.Monitors.K10Temp where
 
 import Xmobar.Plugins.Monitors.Common
 
-import Data.Char (isDigit)
-
 -- |
 -- K10 temperature default configuration. Default template contains only the
 -- die temperature, user should specify custom template in order to get more

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -149,6 +149,7 @@ library
                    Xmobar.Plugins.Monitors.Common.Parsers,
                    Xmobar.Plugins.Monitors.Common.Files,
                    Xmobar.Plugins.Monitors.CoreTemp,
+                   Xmobar.Plugins.Monitors.K10Temp,
                    Xmobar.Plugins.Monitors.CpuFreq,
                    Xmobar.Plugins.Monitors.Disk,
                    Xmobar.Plugins.Monitors.Mem,


### PR DESCRIPTION
The existing support for the coretemp kernel driver only works with
Intel CPUs.

This commit extends support for temperature monitoring to AMD CPUs.

k10temp is a kernel driver for monitoring the temperature of AMD
processors. It supports everything from AMD's 10h (Opteron/Athlon)
family of processors to the latest 19h (Zen 3) family.

Reference: https://www.kernel.org/doc/html/latest/hwmon/k10temp.html

The meaning of the various temperatures made available has changed over
the years and only `Tctl` is available on processors prior to the 17h
family.

Labels for these temperatures are present but as Tctl and Tdie do not
contain a number I could not find a way to use these as
`checkedDataRetrieval` expects an integer label.

It is a PCI device and so an address needs to be supplied as part of the
configuration.

Example configuration:
`Run K10Temp "0000:00:18.3" ["--template", "T: <Tdie>C | <Tccd1>C"] 60`