### PR TITLE
Add show instances for several types so that configs can be generated programmatically

### DIFF
--- a/src/Xmobar/Config/Types.hs
+++ b/src/Xmobar/Config/Types.hs
@@ -65,7 +65,7 @@ data Config =
                                     --   right text alignment
            , template :: String     -- ^ The output template
            , verbose :: Bool        -- ^ Emit additional debug messages
-           } deriving (Read)
+           } deriving (Read, Show)
 
 data XPosition = Top
                | TopW Align Int
@@ -77,9 +77,9 @@ data XPosition = Top
                | BottomSize Align Int Int
                | Static {xpos, ypos, width, height :: Int}
                | OnScreen Int XPosition
-                 deriving ( Read, Eq )
+                 deriving ( Read, Show, Eq )
 
-data Align = L | R | C deriving ( Read, Eq )
+data Align = L | R | C deriving ( Read, Show, Eq )
 
 data Border = NoBorder
             | TopB
@@ -88,4 +88,4 @@ data Border = NoBorder
             | TopBM Int
             | BottomBM Int
             | FullBM Int
-              deriving ( Read, Eq )
+              deriving ( Read, Show, Eq )

--- a/src/Xmobar/Run/Runnable.hs
+++ b/src/Xmobar/Run/Runnable.hs
@@ -34,7 +34,7 @@ instance Exec Runnable where
      trigger (Run a) = trigger a
 
 instance Show Runnable where
-    show (Run x) = show x
+    show (Run x) = "Run " ++ show x
 
 instance Read Runnable where
     readPrec = readRunnable

--- a/src/Xmobar/Run/Runnable.hs-boot
+++ b/src/Xmobar/Run/Runnable.hs-boot
@@ -4,5 +4,6 @@ import Xmobar.Run.Exec
 
 data Runnable = forall r . (Exec r,Read r,Show r) => Run r
 
+instance Show Runnable
 instance Read Runnable
 instance Exec Runnable


### PR DESCRIPTION
In order to run xmobar on *each* of my screens, rather than just one, I need to generate a different .xmobarrc for each one.  That requires adding some `Show` instances to xmobar and exposing some modules.  This PR represents what I'm currently using (and have been for a few years, although I only now got around to cleaning it up).

I don't think this is quite the perfect amount of stuff to expose - it's probably exposing more than it should from some modules, and it definitely isn't exposing enough plugins for all potential users to be able to do the same thing I'm doing.  I'll be happy to clean this up further, but I could use some direction on the best way to approach it.

For reference, here's the code I use to start xmobar:

```haskell
startupXmobar scr = do
  let r = screenRect $ SS.screenDetail scr
  liftIO $ putStrLn $ "starting xmobar on screen " <> show r
  let c = Xmobar.defaultConfig
        { Xmobar.font = "xft: Sans-10"
        , Xmobar.bgColor = "black"
        , Xmobar.fgColor = "grey"
        , Xmobar.position = Xmobar.Static { Xmobar.xpos = fromIntegral (rect_x r) + screenWidth - fromIntegral rightWidth, Xmobar.ypos = fromIntegral (rect_y r), Xmobar.width = fromIntegral rightWidth - trayerWidth, Xmobar.height = xmobarHeight }
        , Xmobar.commands =
          [ Xmobar.Run (Xmobar.Date "%a %b %_d %Y %H:%M" "date" 10)
          , Xmobar.Run (Xmobar.Battery ["-t","<left>%","-L","25","-H","50","-h","grey","-n","yellow","-l","red","-c","energy_full"] 10)
          , Xmobar.Run Xmobar.StdinReader
          ]
        , Xmobar.sepChar = "%"
        , Xmobar.alignSep = "}{"
        , Xmobar.template = "%StdinReader% }{ %battery% %date%"
        }
  io $ writeFile "/home/ryan/.xmobarrc" $ show c
  h <- spawnPipe "xmobar"
  liftIO $ threadDelay 100000 --Needed to ensure xmobar has enough time to read the file before we overwrite it (if startupXmobar is run several times in quick succession)
  return (h, c)

-- Later, down in `main`:
  let startupAllXmobars = do
        liftIO $ do
          killProcess <- runCommand "pkill xmobar ; sleep 0.3"
          _ :: Either SomeException ExitCode <- try $ waitForProcess killProcess
          return ()
        s <- gets windowset
        let screens = SS.current s : SS.visible s
        xmobars <- liftIO $ mapM startupXmobar screens
        liftIO $ writeIORef xmobarRef xmobars

```
