### PR TITLE
NotmuchMail: Properly parse the type for non-Haskell based configurations

### DIFF
--- a/doc/plugins.org
+++ b/doc/plugins.org
@@ -911,18 +911,6 @@ something like:
      ]
    #+end_src
 
-   or, using explicit record syntax:
-
-   #+begin_src haskell
-     [ MailItem
-         { name    = "name"
-         , address = "address"
-         , query   = "query"
-         }
-       ...
-     ]
-   #+end_src
-
    where
 
    - =name= is what gets printed in the status bar before the number of

--- a/src/Xmobar/Plugins/NotmuchMail.hs
+++ b/src/Xmobar/Plugins/NotmuchMail.hs
@@ -39,6 +39,7 @@ import Control.Concurrent.Async (mapConcurrently)
 import Data.Maybe (catMaybes)
 import System.Exit (ExitCode(ExitSuccess))
 import System.Process (readProcessWithExitCode)
+import Text.Read (Lexeme(Ident), ReadPrec, lexP, parens, prec, readPrec, reset)
 
 
 -- | A 'MailItem' is a name, an address, and a query to give to @notmuch@.
@@ -48,7 +49,13 @@ data MailItem = MailItem
                        --   the empty string to query all indexed mail instead
   , query   :: String  -- ^ Query to give to @notmuch search@
   }
-  deriving (Read, Show)
+  deriving (Show)
+
+instance Read MailItem where
+  readPrec :: ReadPrec MailItem
+  readPrec = parens . prec 11 $ do
+    Ident "MailItem" <- lexP
+    MailItem <$> reset readPrec <*> reset readPrec <*> reset readPrec
 
 -- | A full mail configuration.
 data NotmuchMail = NotmuchMail
@@ -56,7 +63,13 @@ data NotmuchMail = NotmuchMail
   , mailItems :: [MailItem]  -- ^ 'MailItem's to check
   , nmRate    :: Int         -- ^ Update frequency (in deciseconds)
   }
-  deriving (Read, Show)
+  deriving (Show)
+
+instance Read NotmuchMail where
+  readPrec :: ReadPrec NotmuchMail
+  readPrec = parens . prec 11 $ do
+    Ident "NotmuchMail" <- lexP
+    NotmuchMail <$> reset readPrec <*> reset readPrec <*> reset readPrec
 
 -- | How to execute this plugin.
 instance Exec NotmuchMail where

--- a/src/Xmobar/Run/Types.hs
+++ b/src/Xmobar/Run/Types.hs
@@ -30,6 +30,7 @@ import Xmobar.Plugins.XMonadLog
 import Xmobar.Plugins.EWMH
 import Xmobar.Plugins.Kbd
 import Xmobar.Plugins.Locks
+import Xmobar.Plugins.NotmuchMail
 
 #ifdef INOTIFY
 import Xmobar.Plugins.Mail
@@ -54,7 +55,7 @@ infixr :*:
 -- this function's type signature.
 runnableTypes :: Command :*: Monitors :*: Date :*: PipeReader :*:
                  BufferedPipeReader :*: CommandReader :*: StdinReader :*:
-                 XMonadLog :*: EWMH :*: Kbd :*: Locks :*:
+                 XMonadLog :*: EWMH :*: Kbd :*: Locks :*: NotmuchMail :*:
 #ifdef INOTIFY
                  Mail :*: MBox :*:
 #endif


### PR DESCRIPTION
Fixes #547 

1.  Add NotmuchMail as a runnable type 

This is needed for the plugin to parse properly in non-Haskell based 
configurations.

2.  NotmuchMail: Manually implement Read instance

The automatically derived read instance expects the type to be given in
record syntax; this is not what most users want.  In order to simply
specify the type via

    Run NotmuchMail "mail" [MailItem "name" "" "tag:unread"] 3000

we have to write our own Read instance.

3.  NotmuchMail: Update documentation

Ever since d51b9d5 we can't specify a
MailItem via the record syntax anymore.  This could conceivably be added
back in by being part of the Read instance, but that would make it more
complicated for perhaps little gain.