### PR TITLE
Fix MultiCoreTemp --hwmon-path argument docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -59,7 +59,7 @@ _Bug fixes_
 _New features_
 
   - `MultiCoreTemp` now works with Ryzen processors.  New option
-    `--hwmonitor-path` for better performance.
+    `--hwmon-path` for better performance.
   - CPU Monitor optimizations.
   - Version bumps for some dependencies, including timezone-olson.
 

--- a/doc/plugins.org
+++ b/doc/plugins.org
@@ -424,7 +424,7 @@ something like:
      limit for percentage calculation.
    - =--maxtemp=: temperature in degree Celsius, that sets the upper
      limit for percentage calculation.
-   - =--hwmonitor-path=: this monitor tries to find coretemp devices by
+   - =--hwmon-path=: this monitor tries to find coretemp devices by
      looking for them in directories following the pattern
      =/sys/bus/platform/devices/coretemp.*/hwmon/hwmon*=, but some
      processors (notably Ryzen) might expose those files in a different


### PR DESCRIPTION
The document seems to be off. in the code `hwmon-path` is parsed from the `Args`