### PR TITLE
Add Gentoo to installation method. 

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -51,6 +51,11 @@ don't have to.
   xbps-install xmobar
 #+end_src
 
+*** Gentoo
+#+begin_src shell
+  emerge --ask xmobar
+#+end_src
+
 ** Using cabal-install
 
 Xmobar is available from [[http://hackage.haskell.org/package/xmobar/][Hackage]], and you can install it using


### PR DESCRIPTION
Xmobar is also avalible under gentoo, so why don't make a installation method there to in the readme?