### PR TITLE
Pass arguments if using xmobar.hs

### DIFF
--- a/src/Xmobar/App/Main.hs
+++ b/src/Xmobar/App/Main.hs
@@ -73,14 +73,14 @@ cleanupThreads vars =
   for_ (concat vars) $ \(asyncs, _) ->
     for_ asyncs cancel
 
-buildLaunch :: Bool -> Bool -> String -> ParseError -> IO ()
-buildLaunch verb force p e = do
+buildLaunch :: [String] -> Bool -> Bool -> String -> ParseError -> IO ()
+buildLaunch args verb force p e = do
   let exec = takeBaseName p
       confDir = takeDirectory p
       ext = takeExtension p
   if ext `elem` [".hs", ".hsc", ".lhs"]
     then xmobarDataDir >>= \dd -> recompile confDir dd exec force verb >>
-         executeFile (confDir </> exec) False [] Nothing
+         executeFile (confDir </> exec) False args Nothing
     else trace True ("Invalid configuration file: " ++ show e) >>
          trace True "\n(No compilation attempted: \
                     \only .hs, .hsc or .lhs files are compiled)"
@@ -106,5 +106,5 @@ xmobarMain = do
     Just p -> do r <- readConfig defaultConfig p
                  case r of
                    Left e ->
-                     buildLaunch (verboseFlag flags) (recompileFlag flags) p e
+                     buildLaunch args (verboseFlag flags) (recompileFlag flags) p e
                    Right (c, defs) -> doOpts c flags >>= xmobar' defs


### PR DESCRIPTION
This is a simple fix in order to pass xmobar command line arguments when invoking `xmobar /path/to/xmobar.hs` to recompiled xmobar. 

For example, if in xmobar.hs `main` function looks like that: 
```
main :: IO ()
main = do
  xs <- getArgs
  case xs of
    ["-x", "1", _] -> xmobar auxConfig
    _              -> xmobar mainConfig
```
Then, the xmobar does not pass any arguments to recompiled xmobar and it simply does not work.  Workaround for that situation is to use recompiled xmobar and then pass any additional arguments, but I am not sure if it is intended behavior. 

This fix enables to pass flag arguments with invoking `xmobar flag /path/to/xmobar.hs` to recompiled xmobar.
More information about this issue could be found in this [reddit discussion](https://new.reddit.com/r/xmonad/comments/oadc6k/spawn_multiple_xmobars_from_one_file/).