### PR TITLE
Filter filename when executing Haskell-based config

### DIFF
--- a/src/Xmobar/App/Main.hs
+++ b/src/Xmobar/App/Main.hs
@@ -106,5 +106,5 @@ xmobarMain = do
     Just p -> do r <- readConfig defaultConfig p
                  case r of
                    Left e ->
-                     buildLaunch args (verboseFlag flags) (recompileFlag flags) p e
+                     buildLaunch (filter (/= p) args) (verboseFlag flags) (recompileFlag flags) p e
                    Right (c, defs) -> doOpts c flags >>= xmobar' defs


### PR DESCRIPTION
We are now—in case the user specified a Haskell file as their xmobar
configuration—threading the command line arguments that xmobar receives
to the relevant execv() call.  However, we simply shove in all arguments
originally given to xmobar, including the path to the configuration
file.  As main is now defined within that very file, this seems
unneccessary.

By filtering out that part of the arguments, the pattern that a lot of
users seem to follow for easy setting of certain options becomes a
little bit nicer.  For example:

    main :: IO ()
    main = getArgs >>= \case
      ["-x", n, _] -> xmobar . config $ read n
      _            -> xmobar $ config 0

becomes

    main :: IO ()
    main = getArgs >>= \case
      ["-x", n] -> xmobar . config $ read n
      _         -> xmobar $ config 0

Related: https://github.com/jaor/xmobar/pull/553