### PR TITLE
Relax base requirements to allow build with GHC 9.0

### DIFF
--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -173,7 +173,7 @@ library
     ghc-options: -funbox-strict-fields -Wall -fno-warn-unused-do-bind
 
     build-depends:
-      base >= 4.11.0 && < 4.15,
+      base >= 4.11.0 && < 4.16,
       containers,
       regex-compat,
       process,


### PR DESCRIPTION
Seem to work fine on my system after this patch (GHC 9.0.1, Archlinux).