### PR TITLE
fix: padString should not make strings longer

### DIFF
--- a/src/Xmobar/Plugins/Monitors/Common/Output.hs
+++ b/src/Xmobar/Plugins/Monitors/Common/Output.hs
@@ -140,7 +140,7 @@ showWithUnits d n x
 padString :: Int -> Int -> String -> Bool -> String -> String -> String
 padString mnw mxw pad pr ellipsis s =
   let len = length s
-      rmin = if mnw <= 0 then 1 else mnw
+      rmin = if mnw < 0 then 0 else mnw
       rmax = if mxw <= 0 then max len rmin else mxw
       (rmn, rmx) = if rmin <= rmax then (rmin, rmax) else (rmax, rmin)
       rlen = min (max rmn len) rmx

--- a/test/Xmobar/Plugins/Monitors/CommonSpec.hs
+++ b/test/Xmobar/Plugins/Monitors/CommonSpec.hs
@@ -13,7 +13,7 @@ spec :: Spec
 spec =
   describe "Common.padString" $ do
     it "returns given string when called with default values" $
-      do padString 0 0 "" False "" "test" `shouldBe` "test"
+      padString 0 0 "" False "" "test" `shouldBe` "test"
 
     it "truncates to max width" $ do
       let maxw = 3
@@ -27,3 +27,9 @@ spec =
           ellipsis = "..."
           expectedStr = (++ ellipsis) . take 3 $ givenStr
       padString 0 maxw "" False ellipsis givenStr `shouldBe` expectedStr
+
+    it "does not pad empty strings" $ do
+      let padChars = " "
+          givenStr = ""
+          expectedStr = ""
+      padString 0 0 padChars False "" givenStr `shouldBe` expectedStr


### PR DESCRIPTION
I first noticed this because this configuration:

```hs
      Run Battery [
        "--template", "<left>%<acstatus>, <timeleft> left",
        "--Low", "40", "--High", "80",
        "--low", "red", "--normal", "yellow", "--high", "green",
        "--",
        "-o", "", "-O", " (Charging)", "-i", " (Charged)"
      ] 60,
```

was somehow rendering as:

```
<fc color="yellow">50</fc>%<fc color="yellow"> </fc>, 3:00 left
```

Notice the extra space where the `""` string from `-o` got padded into `" "`.