### PR TITLE
Fix kbd crashes

### DIFF
--- a/src/Xmobar/System/Kbd.hsc
+++ b/src/Xmobar/System/Kbd.hsc
@@ -113,9 +113,9 @@ data XkbNamesRec = XkbNamesRec {
     symbols :: Atom,
     types :: Atom,
     compat :: Atom,
-    vmods :: Ptr Atom,
-    indicators :: Ptr Atom, -- array
-    groups :: Ptr Atom, -- array
+    vmods :: [Atom], -- Atom              vmods[XkbNumVirtualMods];
+    indicators :: [Atom], -- Atom              indicators[XkbNumIndicators];
+    groups :: [Atom], -- Atom              groups[XkbNumKbdGroups];
     keys :: Ptr XkbKeyNameRec,
     key_aliases :: Ptr CChar, -- dont care XkbKeyAliasRec,
     radio_groups :: Ptr Atom,
@@ -178,9 +178,9 @@ instance Storable XkbNamesRec where
         r_symbols <- (#peek XkbNamesRec, symbols ) ptr
         r_types <- (#peek XkbNamesRec, types ) ptr
         r_compat <- (#peek XkbNamesRec, compat ) ptr
-        r_vmods <- (#peek XkbNamesRec,  vmods ) ptr
-        r_indicators <- (#peek XkbNamesRec, indicators ) ptr
-        r_groups <- (#peek XkbNamesRec, groups ) ptr
+        r_vmods <- peekArray (#const XkbNumVirtualMods) $ (#ptr XkbNamesRec,  vmods ) ptr
+        r_indicators <- peekArray (#const XkbNumIndicators) $ (#ptr XkbNamesRec, indicators ) ptr
+        r_groups <- peekArray (#const XkbNumKbdGroups) $ (#ptr XkbNamesRec, groups ) ptr
         r_keys <- (#peek XkbNamesRec, keys ) ptr
         r_key_aliases <- (#peek XkbNamesRec, key_aliases  ) ptr
         r_radio_groups <- (#peek XkbNamesRec, radio_groups  ) ptr

--- a/src/Xmobar/System/Kbd.hsc
+++ b/src/Xmobar/System/Kbd.hsc
@@ -303,7 +303,7 @@ getLayoutStr dpy =  do
         kbdDescPtr <- xkbAllocKeyboard
         status <- xkbGetNames dpy xkbSymbolsNameMask kbdDescPtr
         str <- getLayoutStr' status dpy kbdDescPtr
-        xkbFreeNames kbdDescPtr xkbGroupNamesMask 1
+        xkbFreeNames kbdDescPtr xkbSymbolsNameMask 1
         xkbFreeKeyboard kbdDescPtr 0 1
         return str
 


### PR DESCRIPTION
Fixes #313 and some related corner cases too. Ran into this myself yesterday, thought I could fix this while at it.

The main point is avoiding partial functions as to not crash/freeze; the rest is mostly fluff, although I did fix what I believe to be a memory leak in `Xmobar.System.Kbd`. Also, `vmods`, `indicators` and `groups` were marshalled incorrectly, so I also fixed that.

I am somewhat unsure about applying `map (map toLower . take 2)` to group names. Perhaps first checking for matches with the full group name in KbdOpts and preferring that is a good idea? Let me know what you think.