### PR TITLE
Add the QueueReader plugin.

### DIFF
--- a/doc/plugins.org
+++ b/doc/plugins.org
@@ -1436,6 +1436,50 @@ choice.
      hPutStr writeHandle "Hello World"
    #+end_src
 
+** Software Transactional Memory
+
+When invoking xmobar from other Haskell code it can be easier and
+more performant to use shared memory.  The following plugins leverage
+=Control.Concurrent.STM= to realize these gains for xmobar.
+
+*** =QueueReader (TQueue a) (a -> String) String=
+
+ - Display data from a Haskell =TQueue a=.
+
+ - This plugin is only useful if you are running xmobar from another
+   haskell program like xmonad.
+
+ - You should make an =IO= safe =TQueue a= with =Control.Concurrent.STM.newTQueueIO=.
+   Write to it from the user code with =writeTQueue=, and read with =readTQueue=.
+   A common use is to overwite =ppOutput= from =XMonad.Hooks.DynamicLog= as shown
+   below.
+
+   #+begin_src haskell
+     main :: IO ()
+     main = do
+       q <- STM.newTQueueIO @String
+       bar <- forkIO $ xmobar myConf
+         { commands = Run (QueueReader q id "XMonadLog") : commands myConf }
+       xmonad $ def { logHook = logWorkspacesToQueue q }
+
+     logWorkspacesToQueue :: STM.TQueue String -> X ()
+     logWorkspacesToQueue q =
+       dynamicLogWithPP def { ppOutput = STM.atomically . STM.writeTQueue q }
+       where
+         -- Manage the PrettyPrinting configuration here.
+         ppLayout' :: String -> String
+         ppLayout' "Spacing Tall"        = xpm "layout-spacing-tall"
+         ppLayout' "Spacing Mirror Tall" = xpm "layout-spacing-mirror"
+         ppLayout' "Spacing Full"        = xpm "layout-full"
+         ppLayout' x = x
+
+         icon :: String -> String
+         icon path = "<icon=" ++ path ++ "/>"
+
+         xpm :: String -> String
+         xpm = icon . (++ ".xpm")
+   #+end_src
+
 * Executing External Commands
 
 In order to execute an external command you can either write the command

--- a/src/Xmobar.hs
+++ b/src/Xmobar.hs
@@ -33,6 +33,7 @@ module Xmobar (xmobar
 #endif
               , module Xmobar.Plugins.EWMH
               , module Xmobar.Plugins.HandleReader
+              , module Xmobar.Plugins.QueueReader
               , module Xmobar.Plugins.Kbd
               , module Xmobar.Plugins.Locks
 #ifdef INOTIFY
@@ -60,6 +61,7 @@ import Xmobar.Plugins.DateZone
 #endif
 import Xmobar.Plugins.EWMH
 import Xmobar.Plugins.HandleReader
+import Xmobar.Plugins.QueueReader
 import Xmobar.Plugins.Kbd
 import Xmobar.Plugins.Locks
 #ifdef INOTIFY

--- a/src/Xmobar/Plugins/QueueReader.hs
+++ b/src/Xmobar/Plugins/QueueReader.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE RecordWildCards #-}
+module Xmobar.Plugins.QueueReader
+  (QueueReader (..)
+  ) where
+
+import Xmobar.Run.Exec (Exec (..))
+
+import Control.Monad (forever)
+import qualified Control.Concurrent.STM as STM
+
+-- | A 'QueueReader' displays data from an 'TQueue a' where
+-- the data items 'a' are rendered by a user supplied function.
+--
+-- Like the 'HandleReader' plugin this is only useful if you are
+-- running @xmobar@ from other Haskell code.  You should create a
+-- new @TQueue a@ and pass it to this plugin.
+--
+-- @
+-- main :: IO
+-- main = do
+--   q <- STM.newQueueIO @String
+--   bar <- forkIO $ xmobar conf
+--     { commands = Run (QueueReader q id "Queue") : commands conf }
+--   STM.atomically $ STM.writeTQueue q "Some Message"
+-- @
+data QueueReader a
+  = QueueReader
+  { qQueue    :: STM.TQueue a
+  , qShowItem :: a -> String
+  , qName :: String
+  }
+
+-- | This cannot be read back.
+instance Show (QueueReader a) where
+  -- | Only show the name/alias for the queue reader.
+  show q = "QueueReader " <> qName q
+
+-- | WARNING: This read instance will throw an exception if used! It is
+-- only implemented, because it is required by 'Xmobar.Run` in 'Xmobar.commands'.
+instance Read (QueueReader a) where
+  -- | Throws an 'error'!
+  readsPrec = error "QueueReader: instance is a stub"
+
+-- | Async queue/channel reading.
+instance Exec (QueueReader a) where
+  -- | Read from queue as data arrives.
+  start QueueReader{..} cb =
+    forever (STM.atomically (qShowItem <$> STM.readTQueue qQueue) >>= cb)
+
+  alias = qName

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -140,6 +140,7 @@ library
                    Xmobar.Plugins.Date,
                    Xmobar.Plugins.EWMH,
                    Xmobar.Plugins.HandleReader,
+                   Xmobar.Plugins.QueueReader,
                    Xmobar.Plugins.PipeReader,
                    Xmobar.Plugins.MarqueePipeReader,
                    Xmobar.Plugins.StdinReader,


### PR DESCRIPTION
  * A queue reader for xmobar using `TQueue a` from `stm`.
    This is a flexible and performat solution for sharing
    data between arbitrary haskell and xmobar.
  * I am not sure if I did the haddocks correctly.

---

Should there be an safe and unsafe version?  If `stripActions` were exposed, then users could make their own safe version trivially.  Let me know.

I ran `hlint`.  No errors in the whole codebase.  Awesome maintenance job you all!

---

I didn't make any tests.  Tests seem hard and unnecessary for this.  The plugin is very simple, so it practically feels tautological, but it feels arrogant to say this.

Let me know if I should make any improvements.