### PR TITLE
Ipc improvements when used from other Haskell code

### DIFF
--- a/src/Xmobar.hs
+++ b/src/Xmobar.hs
@@ -23,6 +23,7 @@ module Xmobar (xmobar
               , Runnable (..)
               , Exec (..)
               , Command (..)
+              , SignalType (..)
               , module Xmobar.Config.Types
               , module Xmobar.Config.Parse
               , module Xmobar.Plugins.BufferedPipeReader
@@ -74,6 +75,8 @@ import Xmobar.Plugins.StdinReader
 import Xmobar.Plugins.MarqueePipeReader
 import Xmobar.Plugins.XMonadLog
 import Xmobar.Plugins.NotmuchMail
+
+import Xmobar.System.Signal(SignalType (..))
 
 import Xmobar.App.Main(xmobar, xmobarMain, configFromArgs)
 import Xmobar.App.Config(defaultConfig)

--- a/src/Xmobar/App/Config.hs
+++ b/src/Xmobar/App/Config.hs
@@ -64,6 +64,7 @@ defaultConfig =
            , template = "%StdinReader% }{ " ++
                         "<fc=#00FF00>%uname%</fc> * <fc=#FF0000>%theDate%</fc>"
            , verbose = False
+           , signal = SignalChan Nothing
            }
 
 -- | Return the path to the xmobar data directory.  This directory is

--- a/src/Xmobar/App/EventLoop.hs
+++ b/src/Xmobar/App/EventLoop.hs
@@ -42,7 +42,7 @@ import Data.Maybe (fromJust, isJust)
 import qualified Data.List.NonEmpty as NE
 
 import Xmobar.System.Signal
-import Xmobar.Config.Types
+import Xmobar.Config.Types (persistent, position, iconRoot, Config, Align(..), XPosition(..))
 import Xmobar.Run.Exec
 import Xmobar.Run.Runnable
 import Xmobar.X11.Actions

--- a/src/Xmobar/App/Main.hs
+++ b/src/Xmobar/App/Main.hs
@@ -18,7 +18,7 @@
 module Xmobar.App.Main (xmobar, xmobarMain, configFromArgs) where
 
 import Control.Concurrent.Async (Async, cancel)
-import Control.Concurrent.STM (TMVar, newEmptyTMVarIO)
+import Control.Concurrent.STM (newEmptyTMVarIO)
 import Control.Exception (bracket)
 import Control.Monad (unless)
 

--- a/src/Xmobar/Config/Parse.hs
+++ b/src/Xmobar/Config/Parse.hs
@@ -57,7 +57,7 @@ parseConfig defaultConfig =
         x <- perms
         eof
         s <- getState
-        return (x,s)
+        return (x (SignalChan Nothing),s)
 
       perms = permute $ Config
               <$?> pFont <|?> pFontList <|?> pWmClass <|?> pWmName

--- a/src/Xmobar/Config/Parse.hs
+++ b/src/Xmobar/Config/Parse.hs
@@ -106,7 +106,8 @@ parseConfig defaultConfig =
       pAlpha = readField alpha "alpha"
       pVerbose = readField verbose "verbose"
 
-      pSignal = field signal "signal" $ fail "use default signal"
+      pSignal = field signal "signal" $
+        fail "signal is meant for use with Xmobar as a library.\n It is not meant for use in the configuration file."
 
       pCommands = field commands "commands" readCommands
 

--- a/src/Xmobar/Config/Parse.hs
+++ b/src/Xmobar/Config/Parse.hs
@@ -57,7 +57,8 @@ parseConfig defaultConfig =
         x <- perms
         eof
         s <- getState
-        return (x (SignalChan Nothing),s)
+        let sig = signal defaultConfig
+        return (x sig ,s)
 
       perms = permute $ Config
               <$?> pFont <|?> pFontList <|?> pWmClass <|?> pWmName

--- a/src/Xmobar/Config/Parse.hs
+++ b/src/Xmobar/Config/Parse.hs
@@ -57,8 +57,7 @@ parseConfig defaultConfig =
         x <- perms
         eof
         s <- getState
-        let sig = signal defaultConfig
-        return (x sig ,s)
+        return (x, s)
 
       perms = permute $ Config
               <$?> pFont <|?> pFontList <|?> pWmClass <|?> pWmName
@@ -69,7 +68,7 @@ parseConfig defaultConfig =
               <|?> pAllDesktops <|?> pOverrideRedirect <|?> pPickBroadest
               <|?> pLowerOnStart <|?> pPersistent <|?> pIconRoot
               <|?> pCommands <|?> pSepChar <|?> pAlignSep <|?> pTemplate
-              <|?> pVerbose
+              <|?> pVerbose <|?> pSignal
 
       fields    = [ "font", "additionalFonts","bgColor", "fgColor"
                   , "wmClass", "wmName", "sepChar"
@@ -77,7 +76,7 @@ parseConfig defaultConfig =
                   , "position" , "textOffset", "textOffsets", "iconOffset"
                   , "allDesktops", "overrideRedirect", "pickBroadest"
                   , "hideOnStart", "lowerOnStart", "persistent", "iconRoot"
-                  , "alpha", "commands", "verbose"
+                  , "alpha", "commands", "verbose", "signal"
                   ]
 
       pFont = strField font "font"
@@ -106,6 +105,8 @@ parseConfig defaultConfig =
       pIconRoot = readField iconRoot "iconRoot"
       pAlpha = readField alpha "alpha"
       pVerbose = readField verbose "verbose"
+
+      pSignal = field signal "signal" $ fail "use default signal"
 
       pCommands = field commands "commands" readCommands
 

--- a/src/Xmobar/Config/Types.hs
+++ b/src/Xmobar/Config/Types.hs
@@ -99,7 +99,7 @@ data Border = NoBorder
 newtype SignalChan = SignalChan { unSignalChan :: Maybe (STM.TMVar SignalType) }
 
 instance Read SignalChan where
-  readsPrec _ s = [ (SignalChan Nothing, s) ]
+  readsPrec _ _ = fail "Trying to read a SignalChan"
 
 instance Show SignalChan where
   show (SignalChan (Just _)) = "SignalChan (Just <tmvar>)"

--- a/src/Xmobar/Config/Types.hs
+++ b/src/Xmobar/Config/Types.hs
@@ -99,7 +99,7 @@ data Border = NoBorder
 newtype SignalChan = SignalChan { unSignalChan :: Maybe (STM.TMVar SignalType) }
 
 instance Read SignalChan where
-  readsPrec _ _ = fail "Trying to read a SignalChan"
+  readsPrec _ _ = fail "SignalChan is not readable from a String"
 
 instance Show SignalChan where
   show (SignalChan (Just _)) = "SignalChan (Just <tmvar>)"

--- a/src/Xmobar/Config/Types.hs
+++ b/src/Xmobar/Config/Types.hs
@@ -17,9 +17,12 @@ module Xmobar.Config.Types
       -- $config
       Config (..)
     , XPosition (..), Align (..), Border(..)
+    , SignalChan (..)
     ) where
 
+import qualified Control.Concurrent.STM as STM
 import Xmobar.Run.Runnable (Runnable(..))
+import Xmobar.System.Signal (SignalType)
 
 -- $config
 -- Configuration data type
@@ -65,6 +68,7 @@ data Config =
                                     --   right text alignment
            , template :: String     -- ^ The output template
            , verbose :: Bool        -- ^ Emit additional debug messages
+           , signal :: SignalChan   -- ^ The signal channel used to send signals to xmobar
            } deriving (Read, Show)
 
 data XPosition = Top
@@ -91,3 +95,12 @@ data Border = NoBorder
             | BottomBM Int
             | FullBM Int
               deriving ( Read, Show, Eq )
+
+newtype SignalChan = SignalChan { unSignalChan :: Maybe (STM.TMVar SignalType) }
+
+instance Read SignalChan where
+  readsPrec _ s = [ (SignalChan Nothing, s) ]
+
+instance Show SignalChan where
+  show (SignalChan (Just _)) = "SignalChan (Just <tmvar>)"
+  show (SignalChan Nothing) = "SignalChan Nothing"

--- a/src/Xmobar/System/Signal.hs
+++ b/src/Xmobar/System/Signal.hs
@@ -60,12 +60,11 @@ parseSignalType :: String -> Maybe SignalType
 parseSignalType = fmap fst . safeHead . reads
 
 -- | Signal handling
-setupSignalHandler :: IO (TMVar SignalType)
-setupSignalHandler = do
-   tid   <- newEmptyTMVarIO
+setupSignalHandler :: TMVar SignalType -> IO ()
+setupSignalHandler tid = do
    installHandler sigUSR2 (Catch $ updatePosHandler tid) Nothing
    installHandler sigUSR1 (Catch $ changeScreenHandler tid) Nothing
-   return tid
+   return ()
 
 updatePosHandler :: TMVar SignalType -> IO ()
 updatePosHandler sig = do


### PR DESCRIPTION
I think this needs some documentation and thought but I can confirm that I can send signals to xmobar without dbus by keeping around the TMVar.

I mentioned this in #571 