### PR TITLE
dynamic pads <lpad=X> and <rpad=X> support

### DIFF
--- a/src/Xmobar/App/Config.hs
+++ b/src/Xmobar/App/Config.hs
@@ -60,6 +60,8 @@ defaultConfig =
            , commands = [ Run $ Date "%a %b %_d %Y * %H:%M:%S" "theDate" 10
                         , Run StdinReader]
            , sepChar = "%"
+           , dynLPad = 0
+           , dynRPad = 0
            , alignSep = "}{"
            , template = "%StdinReader% }{ " ++
                         "<fc=#00FF00>%uname%</fc> * <fc=#FF0000>%theDate%</fc>"

--- a/src/Xmobar/Config/Parse.hs
+++ b/src/Xmobar/Config/Parse.hs
@@ -67,11 +67,11 @@ parseConfig defaultConfig =
               <|?> pBdColor <|?> pBdWidth <|?> pAlpha <|?> pHideOnStart
               <|?> pAllDesktops <|?> pOverrideRedirect <|?> pPickBroadest
               <|?> pLowerOnStart <|?> pPersistent <|?> pIconRoot
-              <|?> pCommands <|?> pSepChar <|?> pAlignSep <|?> pTemplate
+              <|?> pCommands <|?> pSepChar <|?> pDynLPad <|?> pDynRPad <|?> pAlignSep <|?> pTemplate
               <|?> pVerbose
 
       fields    = [ "font", "additionalFonts","bgColor", "fgColor"
-                  , "wmClass", "wmName", "sepChar"
+                  , "wmClass", "wmName", "sepChar", "dynLPad", "dynRPad"
                   , "alignSep" , "border", "borderColor" ,"template"
                   , "position" , "textOffset", "textOffsets", "iconOffset"
                   , "allDesktops", "overrideRedirect", "pickBroadest"
@@ -87,6 +87,8 @@ parseConfig defaultConfig =
       pFgColor = strField fgColor "fgColor"
       pBdColor = strField borderColor "borderColor"
       pSepChar = strField sepChar "sepChar"
+      pDynLPad = readField dynLPad "dynLPad"
+      pDynRPad = readField dynRPad "dynRPad"
       pAlignSep = strField alignSep "alignSep"
       pTemplate = strField template "template"
 

--- a/src/Xmobar/Config/Types.hs
+++ b/src/Xmobar/Config/Types.hs
@@ -61,6 +61,8 @@ data Config =
            , sepChar :: String      -- ^ The character to be used for indicating
                                     --   commands in the output template
                                     --   (default '%')
+           , dynLPad :: Int         -- ^ Dynamic Padding using <lpad=X>
+           , dynRPad :: Int         -- ^ Dynamic Padding using <rpad=X>
            , alignSep :: String     -- ^ Separators for left, center and
                                     --   right text alignment
            , template :: String     -- ^ The output template

--- a/src/Xmobar/X11/Actions.hs
+++ b/src/Xmobar/X11/Actions.hs
@@ -18,7 +18,7 @@ import Text.Regex (Regex, subRegex, mkRegex, matchRegex)
 import Graphics.X11.Types (Button)
 
 data Action = Spawn [Button] String
-                deriving (Eq)
+                deriving (Eq, Show)
 
 runAction :: Action -> IO ()
 runAction (Spawn _ s) = void $ system (s ++ "&")

--- a/src/Xmobar/X11/Draw.hs
+++ b/src/Xmobar/X11/Draw.hs
@@ -60,6 +60,7 @@ drawInWin wr@(Rectangle _ _ wid ht) ~[left,center,right] = do
       getWidth (Text s,cl,i,_) =
         textWidth d (safeIndex fs i) s >>= \tw -> return (Text s,cl,i,fi tw)
       getWidth (Icon s,cl,i,_) = return (Icon s,cl,i,fi $ iconW s)
+      getWidth (Pad p,cl,i,_) = return (Pad p,cl,i,0)
 
   p <- liftIO $ createPixmap d w wid ht
                          (defaultDepthOfScreen (defaultScreenOfDisplay d))
@@ -102,6 +103,7 @@ verticalOffset ht (Text t) fontst voffs _
 verticalOffset ht (Icon _) _ _ conf
   | iconOffset conf > -1 = return $ fi (iconOffset conf)
   | otherwise = return $ fi (ht `div` 2) - 1
+verticalOffset _ (Pad _) _ voffs _ = return $ fi voffs
 
 printString :: Display -> Drawable -> XFont -> GC -> String -> String
             -> Position -> Position -> Position -> Position -> String -> Int -> IO ()
@@ -160,6 +162,7 @@ printStrings dr gc fontlist voffs offs a boxes sl@((s,c,i,l):xs) = do
     (Icon p) -> liftIO $ maybe (return ())
                            (B.drawBitmap d dr gc fc bc offset valign)
                            (lookup p (iconS r))
+    (Pad _) -> liftIO $ return ()
   let triBoxes = tBoxes c
       dropBoxes = filter (\(_,b) -> b `notElem` triBoxes) boxes
       boxes' = map (\((x1,_),b) -> ((x1, offset + l), b)) (filter (\(_,b) -> b `elem` triBoxes) boxes)

--- a/src/Xmobar/X11/Window.hs
+++ b/src/Xmobar/X11/Window.hs
@@ -77,6 +77,16 @@ fi = fromIntegral
 
 setPosition :: Config -> XPosition -> [Rectangle] -> Dimension -> Rectangle
 setPosition c p rs ht =
+  Rectangle (rect_x rPrePad + lOffset)
+            (rect_y rPrePad)
+            (rect_width rPrePad - padLessenWidth)
+            (rect_height rPrePad)
+  where rPrePad = setPosition' c p rs ht
+        lOffset = fi $ dynLPad c
+        padLessenWidth = fi $ dynLPad c + dynRPad c
+
+setPosition' :: Config -> XPosition -> [Rectangle] -> Dimension -> Rectangle
+setPosition' c p rs ht =
   case p' of
     Top -> Rectangle rx ry rw h
     TopP l r -> Rectangle (rx + fi l) ry (rw - fi l - fi r) h


### PR DESCRIPTION
Relating to issue https://github.com/jaor/xmobar/issues/583

Looking for feedback.  I am not an expert on the parsing side of Haskell so that should get extra review.

This PR adds a capability to add dynamic padding to either the right or left side of xmobar.  Example use: making room for system trays.

(unsafe)Stdin can include, for example, <rpad=123> to reserve 123 pixels on the right hand of xmobar.  The xmobar window is shrunk on the right by this amount. 

Note that dynamic padding by <pad/lpad=X> is on top of any padding requested by position TopP BottomP.  I believe this is the right strategy because if someone is using TopP to get a bar sized just so, they still may want dynamic padding in addition to the TopP/BottomP requested amount.

The rpad/lpad are stored as new keys in the Config record.  I welcome suggestions on whether it should be structured differently.

I also added some additional Show derived capabilities to Widgets/etc to aid in debug. 
