### PR TITLE
hspace feature. Initial intent: make space for a tray

### DIFF
--- a/doc/quick-start.org
+++ b/doc/quick-start.org
@@ -215,6 +215,10 @@ The syntax for the output template is as follows:
 - =<fn=1>string</fn>= will print =string= with the first font from
   =additionalFonts=. The index =0= corresponds to the standard font.
 
+- =<hspace=X/>= will insert a blank horizontal space of =X= pixels.
+  For example, to add a blank horizontal space of 123 pixels,
+  =<hspace=123/>= may be used.
+
 - =<icon=/path/to/icon.xbm/>= will insert the given bitmap. XPM image
   format is also supported when compiled with the =with_xpm= flag.
 

--- a/src/Xmobar/App/EventLoop.hs
+++ b/src/Xmobar/App/EventLoop.hs
@@ -265,6 +265,7 @@ updateActions conf (Rectangle _ _ wid _) ~[left,center,right] = do
       iconW i = maybe 0 Bitmap.width (lookup i $ iconS conf)
       getCoords (Text s,_,i,a) = textWidth d (safeIndex fs i) s >>= \tw -> return (a, 0, fi tw)
       getCoords (Icon s,_,_,a) = return (a, 0, fi $ iconW s)
+      getCoords (Hspace w,_,_,a) = return (a, 0, fi w)
       partCoord off xs = map (\(a, x, x') -> (fromJust a, x, x')) $
                          filter (\(a, _,_) -> isJust a) $
                          scanl (\(_,_,x') (a,_,w') -> (a, x', x' + w'))

--- a/src/Xmobar/X11/Actions.hs
+++ b/src/Xmobar/X11/Actions.hs
@@ -18,7 +18,7 @@ import Text.Regex (Regex, subRegex, mkRegex, matchRegex)
 import Graphics.X11.Types (Button)
 
 data Action = Spawn [Button] String
-                deriving (Eq)
+                deriving (Eq, Show)
 
 runAction :: Action -> IO ()
 runAction (Spawn _ s) = void $ system (s ++ "&")

--- a/src/Xmobar/X11/Draw.hs
+++ b/src/Xmobar/X11/Draw.hs
@@ -60,6 +60,7 @@ drawInWin wr@(Rectangle _ _ wid ht) ~[left,center,right] = do
       getWidth (Text s,cl,i,_) =
         textWidth d (safeIndex fs i) s >>= \tw -> return (Text s,cl,i,fi tw)
       getWidth (Icon s,cl,i,_) = return (Icon s,cl,i,fi $ iconW s)
+      getWidth (Hspace p,cl,i,_) = return (Hspace p,cl,i,fi p)
 
   p <- liftIO $ createPixmap d w wid ht
                          (defaultDepthOfScreen (defaultScreenOfDisplay d))
@@ -102,6 +103,7 @@ verticalOffset ht (Text t) fontst voffs _
 verticalOffset ht (Icon _) _ _ conf
   | iconOffset conf > -1 = return $ fi (iconOffset conf)
   | otherwise = return $ fi (ht `div` 2) - 1
+verticalOffset _ (Hspace _) _ voffs _ = return $ fi voffs
 
 printString :: Display -> Drawable -> XFont -> GC -> String -> String
             -> Position -> Position -> Position -> Position -> String -> Int -> IO ()
@@ -160,6 +162,7 @@ printStrings dr gc fontlist voffs offs a boxes sl@((s,c,i,l):xs) = do
     (Icon p) -> liftIO $ maybe (return ())
                            (B.drawBitmap d dr gc fc bc offset valign)
                            (lookup p (iconS r))
+    (Hspace _) -> liftIO $ return ()
   let triBoxes = tBoxes c
       dropBoxes = filter (\(_,b) -> b `notElem` triBoxes) boxes
       boxes' = map (\((x1,_),b) -> ((x1, offset + l), b)) (filter (\(_,b) -> b `elem` triBoxes) boxes)


### PR DESCRIPTION
Alternate approach to #583 using by adding <hspace=XXX/> feature.

Example use, in ```xmonad.hs```:
```haskell
main = do
  mySB <- statusBarPipe "xmobar" (pure myPP)
  xmonad $ withSB mySB myConf
-- where myConf includes myTrayEventHook

myTrayEventHook :: Event -> X All
myTrayEventHook (PropertyEvent { ev_window = w }) = do
    whenX (runQuery checkDock w <&&> (runQuery panelQuery w)) (
      withDisplay $ \d -> withWindowAttributes d w $ \wa -> do
        let pixelPad = (fromIntegral $ wa_width wa)
        spawn $ "echo \"PropertyEvent: " ++ show w ++ "\"  >> ~/.xmonad/debug.log" 
        xmonadPropLog' "_XMONAD_PAD" ("<hspace=" ++ show pixelPad ++ "/>")
      )
    return (All True)
myTrayEventHook (UnmapEvent { ev_window = w }) = do
    whenX (runQuery checkDock w <&&> (runQuery panelQuery w)) (
      withDisplay $ \d -> withWindowAttributes d w $ \wa -> do
        spawn $ "echo \"UnmapEvent: " ++ show w ++ "\"  >> ~/.xmonad/debug.log" 
        xmonadPropLog' "_XMONAD_PAD" "<hspace=0/>"
      )
    return (All True)
myTrayEventHook _ = return (All True)

panelQuery :: Query Bool
panelQuery = appName =? "panel"
```

in ```xmobarrc```:
```
Config { ...
       , commands = [ Run XPropertyLog "_XMONAD_LOG" 
                    , Run XPropertyLog "_XMONAD_PAD", ... ]
       , template = "%_XMONAD_LOG% }{ ... %_XMONAD_PAD%"
       }
```

