### PR TITLE
Fix memory leak in drawInWin

### DIFF
--- a/src/Xmobar/X11/Draw.hs
+++ b/src/Xmobar/X11/Draw.hs
@@ -70,6 +70,7 @@ drawInWin wr@(Rectangle _ _ wid ht) ~[left,center,right] = do
 #endif
   withColors d [bgColor c, borderColor c] $ \[bgcolor, bdcolor] -> do
     gc <- liftIO $ createGC  d w
+    liftIO $ setGraphicsExposures d gc False
 #if XFT
     when (alpha c == 255) $ do
 #else
@@ -88,8 +89,8 @@ drawInWin wr@(Rectangle _ _ wid ht) ~[left,center,right] = do
     -- free up everything (we do not want to leak memory!)
     liftIO $ freeGC d gc
     liftIO $ freePixmap d p
-    -- resync
-    liftIO $ sync d False
+    -- resync (discard events, we don't read/process events from this display conn)
+    liftIO $ sync d True
 
 verticalOffset :: (Integral b, Integral a, MonadIO m) =>
                   a -> Widget -> XFont -> Int -> Config -> m b


### PR DESCRIPTION
In f8c835a33a7a, I flipped the discard flag to XSync to False on a false assumption that it may discard events from under the eventer thread (since renamed to handleXEvent). This can't happen—the eventer thread and the main loop do not share a Display connection, they have two separate ones. Turns out, the main loop doesn't read/process any events from its Display connection, which is why it was necessary to discard them once in a while.

The fix restores that discarding, adds a comment to explain why that discarding should stay, and just to make things a bit cleaner, also prevents some of those events from being emitted in the first place: by configuring the graphics context that we don't want any exposure events (<https://tronche.com/gui/x/xlib/events/exposure/graphics-expose-and-no-expose.html>).

Fixes: f8c835a33a7a ("Fix delayed reaction to USR1/2 signals")

---

plus a refactor to improve naming of event/signal loop functions (f50453a)