### PR TITLE
Documentation: QueueReader docs improvements

### DIFF
--- a/doc/window-managers.org
+++ b/doc/window-managers.org
@@ -208,19 +208,6 @@ choice.
           logWorkspacesToQueue :: STM.TQueue String -> X ()
           logWorkspacesToQueue q =
             dynamicLogWithPP def { ppOutput = STM.atomically . STM.writeTQueue q }
-            where
-              -- Manage the PrettyPrinting configuration here.
-              ppLayout' :: String -> String
-              ppLayout' "Spacing Tall"        = xpm "layout-spacing-tall"
-              ppLayout' "Spacing Mirror Tall" = xpm "layout-spacing-mirror"
-              ppLayout' "Spacing Full"        = xpm "layout-full"
-              ppLayout' x = x
-
-              icon :: String -> String
-              icon path = "<icon=" ++ path ++ "/>"
-
-              xpm :: String -> String
-              xpm = icon . (++ ".xpm")
         #+end_src
 *** Example for using the DBus IPC interface with XMonad
 

--- a/doc/window-managers.org
+++ b/doc/window-managers.org
@@ -200,8 +200,9 @@ choice.
         #+begin_src haskell
           main :: IO ()
           main = do
+            initThreads
             q <- STM.newTQueueIO @String
-            bar <- forkIO $ xmobar myConf
+            bar <- forkOS $ xmobar myConf
               { commands = Run (QueueReader q id "XMonadLog") : commands myConf }
             xmonad $ def { logHook = logWorkspacesToQueue q }
 

--- a/doc/window-managers.org
+++ b/doc/window-managers.org
@@ -210,6 +210,15 @@ choice.
           logWorkspacesToQueue q =
             dynamicLogWithPP def { ppOutput = STM.atomically . STM.writeTQueue q }
         #+end_src
+
+        Note that xmonad uses blocking Xlib calls in its event loop and isn't
+        normally compiled with
+        [[https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/using-concurrent.html][the threaded RTS]]
+        so an xmobar thread running inside xmonad will suffer from delayed
+        updates. It is thus necessary to enable =-threaded= when compiling
+        xmonad configuration (=xmonad.hs=), e.g. by using a custom
+        =~/.xmonad/build= script.
+
 *** Example for using the DBus IPC interface with XMonad
 
     Bind the key which should {,un}map xmobar to a dummy value. This is


### PR DESCRIPTION
#### [Documentation: Drop unused fragment in QueueReader example](../commit/80b8030505699e9a734ea83423d526d97e0684ec)

Related: https://github.com/jaor/xmobar/issues/571

#### [Documentation: More robust QueueReader example](../commit/7cca823651a4a33e0c99d4062a382704f7904572)

1. Call `initThreads` early because there's no guarantee the xmobar
   thread will do this before xmonad makes any Xlib calls (although it's
   likely as xmonad startup is probably more expensive).

2. Use `forkOS` to fail early if running in a non-threaded RTS. Also,
   xmobar's own main thread would normally be a bound thread, so this
   may (likely non-observably) result in more consistent behaviour.

Related: https://github.com/jaor/xmobar/issues/571

#### [Documentation: Note the need for threaded RTS with QueueReader & xmonad](../commit/efa9e4c541695e725d39da001592c9613acc4cae)

Related: https://github.com/jaor/xmobar/issues/571