### PR TITLE
Fix MultiCoreTemp's temperature file finding logic

### DIFF
--- a/src/Xmobar/Plugins/Monitors/MultiCoreTemp.hs
+++ b/src/Xmobar/Plugins/Monitors/MultiCoreTemp.hs
@@ -122,7 +122,7 @@ corePaths :: Maybe String -> IO [String]
 corePaths s = do ps <- case s of
                         Just pth -> return [pth]
                         _ -> hwmonPaths
-                 cps <- concat <$> traverse (flip getMatchingPathsInDir corePathMatcher) ps
+                 cps <- concat <$> traverse (`getMatchingPathsInDir` corePathMatcher) ps
                  ls <- filterM doesFileExist cps
                  cls <- filterM isLabelFromCore ls
                  return $ map labelToCore cls


### PR DESCRIPTION
Instead of searching for a fixed set of files and directories (numbered
0-9), which would miss anything above 9, it now searches the relevant
directories for files matching the right pattern, regardless of number.

Fixes #616.