### PR TITLE
Remove with_utf8 option and enable its features by default.

### DIFF
--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -32,10 +32,6 @@ flag with_xft
   description: Use Xft to render text. UTF-8 support included.
   default: False
 
-flag with_utf8
-  description: With UTF-8 support.
-  default: True
-
 flag with_inotify
   description: inotify support (modern Linux only). Required for the Mail and MBox plugins.
   default: False
@@ -187,6 +183,8 @@ library
 
     ghc-options: -funbox-strict-fields -Wall -fno-warn-unused-do-bind
 
+    cpp-options: -DUTF8
+
     build-depends:
                   X11 >= 1.6.1,
                   aeson >= 1.4.7.1,
@@ -206,7 +204,8 @@ library
                   stm >= 2.3 && < 2.6,
                   time,
                   transformers,
-                  unix
+                  unix,
+                  utf8-string >= 0.3 && < 1.1
 
     if impl(ghc < 8.0.2)
        -- Disable building with GHC before 8.0.2.
@@ -228,10 +227,6 @@ library
        build-depends: utf8-string >= 0.3 && < 1.1, X11-xft >= 0.2 && < 0.4
        other-modules: Xmobar.X11.MinXft
        cpp-options: -DXFT
-
-    if flag(with_utf8) || flag(all_extensions)
-       build-depends: utf8-string >= 0.3 && < 1.1
-       cpp-options: -DUTF8
 
     if flag(with_inotify) || flag(all_extensions)
        build-depends: hinotify >= 0.3 && < 0.5


### PR DESCRIPTION
It is not possible to build xmobar without this option enabled:

```
src/Xmobar/Text/SwaybarClicks.hs:34:1: error:
    Could not find module `Data.ByteString.Lazy.UTF8'
    Perhaps you meant
      Data.ByteString.Lazy.Char8 (from bytestring-0.11.3.0)
      Data.ByteString.Lazy (from bytestring-0.11.3.0)
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
34 | import Data.ByteString.Lazy.UTF8 (fromString)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```